### PR TITLE
feat: Perplexity UI, multi-model pipeline UI, CORE API

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,6 +10,7 @@ model:
   # - "openai" - OpenAI API (requires OPENAI_API_KEY)
   # - "anthropic" - Anthropic Claude (requires ANTHROPIC_API_KEY)
   # - "groq" - Groq API with free tier (requires GROQ_API_KEY)
+  # - "perplexity" - Perplexity AI with web-grounded models (requires PERPLEXITY_API_KEY)
   # - "openrouter" - OpenRouter with free models (requires OPENROUTER_API_KEY)
   # - "ollama" - Local Ollama server
   # - "huggingface" - Local HuggingFace models (requires GPU)
@@ -20,10 +21,11 @@ model:
   # 1. OPENAI_API_KEY -> use OpenAI
   # 2. ANTHROPIC_API_KEY -> use Anthropic (Claude)
   # 3. GROQ_API_KEY -> use Groq (free tier!)
-  # 4. OPENROUTER_API_KEY -> use OpenRouter (has free models)
-  # 5. Ollama server -> use Ollama if running
-  # 6. GPU available -> use HuggingFace
-  # 7. Nothing -> retrieval-only mode (still works!)
+  # 4. PERPLEXITY_API_KEY -> use Perplexity AI
+  # 5. OPENROUTER_API_KEY -> use OpenRouter (has free models)
+  # 6. Ollama server -> use Ollama if running
+  # 7. GPU available -> use HuggingFace
+  # 8. Nothing -> retrieval-only mode (still works!)
 
   provider: "groq"
 
@@ -129,8 +131,8 @@ search:
   # Web search for grey literature
   web_search:
     enabled: true
-    provider: "duckduckgo"  # "duckduckgo" (free, no key), "tavily", or "serper"
-    # API key loaded from environment: TAVILY_API_KEY or SERPER_API_KEY
+    provider: "duckduckgo"  # "duckduckgo" (free, no key), "tavily", "serper", or "perplexity"
+    # API key loaded from environment: TAVILY_API_KEY, SERPER_API_KEY, or PERPLEXITY_API_KEY
 
 # ============================================
 # Knowledge Base Ingestion

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -43,10 +43,32 @@ model:
   # Multi-model pipeline: assign different models per task type.
   # If unset, every task uses the default model above.
   # Task types: classify, extract_keywords, synthesize
-  # pipeline:
-  #   classify: "llama-3.1-8b-instant"          # fast/cheap for classification
-  #   extract_keywords: "llama-3.1-8b-instant"   # fast for keyword extraction
-  #   synthesize: "llama-3.3-70b-versatile"      # capable for synthesis
+  #
+  # Use "fast" or "default" aliases — they resolve to the active provider's
+  # recommended models automatically (see PROVIDER_PIPELINE_DEFAULTS in main.py).
+  # Or specify literal model names for full control.
+  pipeline:
+    classify: "fast"              # cheap/fast model for classification
+    extract_keywords: "fast"      # cheap/fast model for keyword extraction
+    synthesize: "default"         # main capable model for synthesis
+  #
+  # Provider-specific examples (literal model names):
+  # Groq free tier:
+  #   classify: "llama-3.1-8b-instant"
+  #   extract_keywords: "llama-3.1-8b-instant"
+  #   synthesize: "llama-3.3-70b-versatile"
+  # OpenAI:
+  #   classify: "gpt-4o-mini"
+  #   extract_keywords: "gpt-4o-mini"
+  #   synthesize: "gpt-4o"
+  # Anthropic:
+  #   classify: "claude-haiku-4-5"
+  #   extract_keywords: "claude-haiku-4-5"
+  #   synthesize: "claude-sonnet-4-6"
+  # Ollama:
+  #   classify: "llama3.2:3b"
+  #   extract_keywords: "llama3.2:3b"
+  #   synthesize: "qwen3:32b"
 
   # OpenAI settings (provider: "openai")
   openai:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -150,6 +150,11 @@ search:
     enabled: true
     email: null  # Optional: for polite pool
     
+  core:
+    enabled: true
+    # CORE_API_KEY env var. Free tier works without key.
+    api_key: null
+
   # Web search for grey literature
   web_search:
     enabled: true

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,8 +7,9 @@ Active priorities and future ideas for the Research Agent.
 - [x] **Auto-Save Web Results from Researcher Lookup** — save DuckDuckGo results to `web_sources`, "Save to KB" button next to each result
 - [x] **Auto-Save Citation Abstracts** — persist cited/citing paper abstracts to KB via S2 batch API, auto-save toggle in Citation Explorer
 - [x] **Additional Cloud LLM Providers** — Gemini, Mistral, xAI/Grok via OpenAI-compatible APIs
-- [ ] **Multi-Model Pipeline** — fast/cheap model for query classification, capable model for synthesis, configurable per task type
-- [ ] **Perplexity Integration** — web-grounded answers with citations, replace/augment DuckDuckGo
+- [x] **Multi-Model Pipeline** — fast/cheap model for query classification, capable model for synthesis, configurable per task type via UI
+- [x] **Perplexity Integration** — web-grounded answers with citations, switchable web search provider (DuckDuckGo/Perplexity/Tavily/Serper)
+- [x] **CORE API Integration** — 300M+ open access papers, integrated into external search pipeline
 
 ## Medium Priority
 

--- a/src/research_agent/main.py
+++ b/src/research_agent/main.py
@@ -71,6 +71,13 @@ CLOUD_PROVIDERS = {
         "default_model": "grok-3-mini-fast",
         "models": ["grok-3-mini-fast", "grok-3-mini", "grok-3-fast", "grok-3"],
     },
+    "perplexity": {
+        "name": "Perplexity AI",
+        "base_url": "https://api.perplexity.ai",
+        "api_key_env": "PERPLEXITY_API_KEY",
+        "default_model": "sonar",
+        "models": ["sonar", "sonar-pro", "sonar-reasoning"],
+    },
 }
 
 
@@ -92,10 +99,11 @@ def detect_available_provider(config: dict) -> Tuple[str, Optional[dict]]:
     1. OpenAI (if OPENAI_API_KEY is set)
     2. Anthropic (if ANTHROPIC_API_KEY is set)
     3. Groq (if GROQ_API_KEY is set - free tier!)
-    4. OpenRouter (if OPENROUTER_API_KEY is set)
-    5. Ollama (if server is reachable)
-    6. HuggingFace (local, requires GPU)
-    7. None (retrieval-only mode)
+    4. Perplexity (if PERPLEXITY_API_KEY is set)
+    5. OpenRouter (if OPENROUTER_API_KEY is set)
+    6. Ollama (if server is reachable)
+    7. HuggingFace (local, requires GPU)
+    8. None (retrieval-only mode)
 
     Returns:
         Tuple of (provider_name, provider_config) or (provider_name, None) for local providers
@@ -103,7 +111,7 @@ def detect_available_provider(config: dict) -> Tuple[str, Optional[dict]]:
     model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
 
     # Check cloud providers in priority order
-    for provider_key in ["openai", "anthropic", "groq", "gemini", "mistral", "xai", "openrouter"]:
+    for provider_key in ["openai", "anthropic", "groq", "perplexity", "gemini", "mistral", "xai", "openrouter"]:
         provider = CLOUD_PROVIDERS[provider_key]
         api_key = os.getenv(provider["api_key_env"])
         if api_key:
@@ -399,6 +407,8 @@ def build_agent_from_config(config: dict):
         web_api_key = os.getenv("TAVILY_API_KEY")
     elif web_provider == "serper":
         web_api_key = os.getenv("SERPER_API_KEY")
+    elif web_provider == "perplexity":
+        web_api_key = os.getenv("PERPLEXITY_API_KEY")
 
     web_search = WebSearchTool(api_key=web_api_key, provider=web_provider)
 

--- a/src/research_agent/tools/researcher_lookup.py
+++ b/src/research_agent/tools/researcher_lookup.py
@@ -34,7 +34,13 @@ class AuthorPaper(BasePaper):
     """A paper authored by a researcher.
 
     Inherits all fields from BasePaper. Source defaults to "unknown".
+    Enrichment fields are populated after initial lookup by
+    ``enrich_papers_oa_status()`` and the S2 batch embedding endpoint.
     """
+
+    oa_status: Optional[str] = None
+    open_access_url: Optional[str] = None
+    tldr: Optional[str] = None
 
     def __post_init__(self):
         if self.source is None:

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -67,6 +67,21 @@ class WebSearchTool:
             await self._client.aclose()
             self._client = None
 
+    def set_provider(self, provider: str, api_key: str | None = None) -> None:
+        """Switch web search provider at runtime.
+
+        Args:
+            provider: One of "duckduckgo", "tavily", "serper", "perplexity".
+            api_key: API key for the new provider (required for tavily/serper/perplexity).
+        """
+        valid = {"duckduckgo", "tavily", "serper", "perplexity"}
+        if provider not in valid:
+            raise ValueError(f"Unknown provider: {provider}. Valid: {valid}")
+        self.provider = provider
+        if api_key is not None:
+            self.api_key = api_key
+        logger.info("Web search provider switched to: %s", provider)
+
     @timed
     async def search(
         self,

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -6,6 +6,7 @@ Supports multiple providers:
 - DuckDuckGo (free, no API key required)
 - Tavily (optimized for AI, requires API key)
 - Serper (Google search results, requires API key)
+- Perplexity (web-grounded answers with citations, requires API key)
 """
 
 import asyncio
@@ -83,6 +84,8 @@ class WebSearchTool:
             return await self._search_tavily(query, max_results)
         elif self.provider == "serper":
             return await self._search_serper(query, max_results)
+        elif self.provider == "perplexity":
+            return await self._search_perplexity(query, max_results)
         else:
             raise ValueError(f"Unknown provider: {self.provider}")
 
@@ -249,3 +252,125 @@ class WebSearchTool:
         except httpx.HTTPError as e:
             logger.error(f"Serper API error: {e}")
             return []
+
+    async def _search_perplexity(
+        self,
+        query: str,
+        max_results: int
+    ) -> List[WebResult]:
+        """
+        Search using Perplexity's sonar model for web-grounded answers.
+
+        Returns a synthesized answer with cited sources.
+        Each citation URL becomes a WebResult.
+        Requires PERPLEXITY_API_KEY.
+        """
+        if not self.api_key:
+            raise ValueError(
+                "Perplexity API key required. Set PERPLEXITY_API_KEY in your environment."
+            )
+
+        client = await self._get_client()
+
+        try:
+            response = await retry_with_backoff(
+                lambda: client.post(
+                    "https://api.perplexity.ai/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": "sonar",
+                        "messages": [
+                            {"role": "user", "content": f"Search: {query}"}
+                        ],
+                    },
+                ),
+                max_retries=2, base_delay=1.0, retry_on=(429, 503, 504),
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # Extract the synthesized answer
+            content = ""
+            if data.get("choices"):
+                content = data["choices"][0].get("message", {}).get("content", "")
+
+            # Extract citations (list of URLs at the top level of the response)
+            citations = data.get("citations", [])
+
+            results = []
+            if citations:
+                # Build one WebResult per citation, linking snippet context
+                for i, url in enumerate(citations[:max_results]):
+                    # Try to extract the snippet around the citation reference [i+1]
+                    marker = f"[{i + 1}]"
+                    snippet = _extract_citation_snippet(content, marker)
+                    title = _title_from_url(url)
+
+                    results.append(WebResult(
+                        title=title,
+                        url=url,
+                        content=snippet or content,
+                        raw_content=content if i == 0 else None,
+                        score=None,
+                    ))
+            elif content:
+                # No citations returned — wrap the whole answer as a single result
+                results.append(WebResult(
+                    title=f"Perplexity answer: {query[:80]}",
+                    url="",
+                    content=content,
+                    raw_content=content,
+                    score=None,
+                ))
+
+            logger.info(
+                f"Perplexity found {len(results)} results for: {query}"
+            )
+            return results
+
+        except httpx.HTTPError as e:
+            logger.error(f"Perplexity API error: {e}")
+            return []
+
+
+def _extract_citation_snippet(content: str, marker: str, context_chars: int = 200) -> str:
+    """Extract text surrounding a citation marker like [1] from the response."""
+    import re
+    # Escape the marker for regex (brackets are special)
+    escaped = re.escape(marker)
+    # Find the sentence(s) containing this marker
+    # Look for text around the marker
+    match = re.search(escaped, content)
+    if not match:
+        return ""
+    start = max(0, match.start() - context_chars)
+    end = min(len(content), match.end() + context_chars)
+    snippet = content[start:end].strip()
+    # Clean up partial words at boundaries
+    if start > 0:
+        snippet = "..." + snippet.split(" ", 1)[-1] if " " in snippet else "..." + snippet
+    if end < len(content):
+        snippet = snippet.rsplit(" ", 1)[0] + "..." if " " in snippet else snippet + "..."
+    return snippet
+
+
+def _title_from_url(url: str) -> str:
+    """Derive a readable title from a URL."""
+    from urllib.parse import urlparse
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.replace("www.", "")
+        # Use the last meaningful path segment as a hint
+        path_parts = [p for p in parsed.path.strip("/").split("/") if p]
+        if path_parts:
+            slug = path_parts[-1].replace("-", " ").replace("_", " ")
+            # Truncate very long slugs
+            if len(slug) > 60:
+                slug = slug[:57] + "..."
+            return f"{slug} ({domain})"
+        return domain
+    except Exception:
+        return url[:80]

--- a/tests/test_core_search.py
+++ b/tests/test_core_search.py
@@ -1,0 +1,157 @@
+"""Tests for CORE API integration in AcademicSearchTools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+SAMPLE_CORE_RESPONSE = {
+    "totalHits": 2,
+    "results": [
+        {
+            "id": 12345,
+            "title": "Indigenous Knowledge Systems in the Arctic",
+            "abstract": "This paper examines indigenous knowledge systems...",
+            "yearPublished": 2021,
+            "authors": [{"name": "Kramvig, B."}, {"name": "Kristoffersen, B."}],
+            "doi": "https://doi.org/10.1234/test.2021",
+            "downloadUrl": "https://core.ac.uk/download/pdf/12345.pdf",
+            "citationCount": 15,
+            "publisher": "Arctic Research Journal",
+            "sourceFulltextUrls": [],
+        },
+        {
+            "id": 67890,
+            "title": "Climate Adaptation in Northern Communities",
+            "abstract": "Northern communities face unique challenges...",
+            "yearPublished": 2020,
+            "authors": [{"name": "Harvey, D."}],
+            "doi": "10.5678/climate.2020",
+            "downloadUrl": None,
+            "citationCount": 8,
+            "publisher": None,
+            "sourceFulltextUrls": ["https://example.com/paper.pdf"],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def mock_academic_search():
+    """Create AcademicSearchTools with mocked HTTP client."""
+    from research_agent.tools.academic_search import AcademicSearchTools
+    tools = AcademicSearchTools(config={"core": {"api_key": "test-key"}}, cache_enabled=False)
+    return tools
+
+
+class TestSearchCore:
+    @pytest.mark.asyncio
+    async def test_returns_papers(self, mock_academic_search):
+        """CORE search parses response into Paper objects."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("arctic indigenous knowledge")
+
+        assert len(papers) == 2
+        assert papers[0].title == "Indigenous Knowledge Systems in the Arctic"
+        assert papers[0].source == "core"
+        assert papers[0].doi == "10.1234/test.2021"  # stripped https://doi.org/
+        assert papers[0].year == 2021
+        assert len(papers[0].authors) == 2
+
+    @pytest.mark.asyncio
+    async def test_doi_without_prefix(self, mock_academic_search):
+        """DOIs without https://doi.org/ prefix are kept as-is."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("climate")
+
+        # Second paper has doi without prefix
+        assert papers[1].doi == "10.5678/climate.2020"
+
+    @pytest.mark.asyncio
+    async def test_fallback_download_url(self, mock_academic_search):
+        """Falls back to sourceFulltextUrls when downloadUrl is None."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("climate")
+
+        assert papers[1].open_access_url == "https://example.com/paper.pdf"
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty(self, mock_academic_search):
+        """HTTP errors return empty list."""
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(side_effect=Exception("Connection refused"))
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("test query")
+
+        assert papers == []
+
+    @pytest.mark.asyncio
+    async def test_year_filter_in_query(self, mock_academic_search):
+        """Year filters are appended to query string."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            await mock_academic_search.search_core("test", from_year=2020, to_year=2023)
+
+            # Check the query parameter includes year filters
+            call_args = client.get.call_args
+            params = call_args.kwargs.get("params") or call_args[1].get("params")
+            assert "yearPublished>=2020" in params["q"]
+            assert "yearPublished<=2023" in params["q"]
+
+    @pytest.mark.asyncio
+    async def test_no_api_key(self):
+        """Works without API key (no Authorization header)."""
+        from research_agent.tools.academic_search import AcademicSearchTools
+        tools = AcademicSearchTools(config={}, cache_enabled=False)
+        assert tools._core_api_key is None
+
+    @pytest.mark.asyncio
+    async def test_caching(self):
+        """Cached results are returned without API call."""
+        from research_agent.tools.academic_search import AcademicSearchTools
+        tools = AcademicSearchTools(config={}, cache_enabled=True)
+
+        # Manually populate cache
+        from research_agent.utils.cache import make_cache_key
+        cache_key = make_cache_key("core_search", "test query", limit=20, from_year=None, to_year=None)
+        cached_papers = [{"title": "Cached Paper", "source": "core"}]
+        tools._cache.set(cache_key, cached_papers, ttl=3600)
+
+        papers = await tools.search_core("test query")
+        assert len(papers) == 1
+        assert papers[0]["title"] == "Cached Paper"

--- a/tests/test_enrichment_caching.py
+++ b/tests/test_enrichment_caching.py
@@ -1,0 +1,261 @@
+"""Tests for enrichment caching: AuthorPaper fields, ResearcherStore enrichment, and injection."""
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from research_agent.tools.researcher_lookup import AuthorPaper, ResearcherProfile
+from research_agent.db.researcher_store import ResearcherStore
+from research_agent.explorer.graph_builder import GraphBuilder
+
+
+# ---------------------------------------------------------------------------
+# AuthorPaper enrichment fields
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorPaperEnrichmentFields:
+    def test_fields_exist_and_default_to_none(self):
+        p = AuthorPaper(paper_id="p1", title="Test Paper")
+        assert p.oa_status is None
+        assert p.open_access_url is None
+        assert p.tldr is None
+
+    def test_fields_survive_to_dict(self):
+        p = AuthorPaper(
+            paper_id="p1",
+            title="Test Paper",
+            oa_status="gold",
+            open_access_url="https://example.com/pdf",
+            tldr="A short summary of the paper.",
+        )
+        d = p.to_dict()
+        assert d["oa_status"] == "gold"
+        assert d["open_access_url"] == "https://example.com/pdf"
+        assert d["tldr"] == "A short summary of the paper."
+
+    def test_source_defaults_to_unknown(self):
+        p = AuthorPaper(paper_id="p1", title="Test Paper")
+        assert p.source == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# ResearcherStore enrichment roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(name="Alice Smith", papers=None):
+    return ResearcherProfile(
+        name=name,
+        normalized_name=name.lower().strip(),
+        openalex_id="A111",
+        semantic_scholar_id="S222",
+        affiliations=["MIT"],
+        works_count=50,
+        citations_count=2000,
+        h_index=25,
+        fields=["Sociology"],
+        top_papers=papers or [
+            AuthorPaper(
+                paper_id="p1",
+                title="Paper One",
+                doi="10.1000/one",
+                oa_status="gold",
+                open_access_url="https://example.com/p1.pdf",
+                tldr="Summary of paper one.",
+            ),
+            AuthorPaper(
+                paper_id="p2",
+                title="Paper Two",
+                doi="10.1000/two",
+            ),
+        ],
+    )
+
+
+class TestResearcherStoreEnrichmentRoundtrip:
+    def setup_method(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = ResearcherStore(path=f"{self.tmpdir}/test.sqlite")
+
+    def test_paper_enrichment_fields_persist(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        loaded = self.store.load_researcher("alice smith")
+        assert loaded is not None
+        p1 = next(p for p in loaded.top_papers if p.paper_id == "p1")
+        assert p1.oa_status == "gold"
+        assert p1.open_access_url == "https://example.com/p1.pdf"
+        assert p1.tldr == "Summary of paper one."
+
+        p2 = next(p for p in loaded.top_papers if p.paper_id == "p2")
+        assert p2.oa_status is None
+        assert p2.open_access_url is None
+        assert p2.tldr is None
+
+    def test_enrichment_artifacts_save_and_load(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        embeddings = {"p1": [0.1] * 768, "p2": [0.2] * 768}
+        ref_map = {"10.1000/one": ["10.2000/ref1", "10.2000/ref2"]}
+        tldrs = {"p1": "Summary of paper one.", "p2": "Summary of paper two."}
+
+        self.store.save_researcher_enrichment(
+            "alice smith", embeddings=embeddings, ref_map=ref_map, tldrs=tldrs,
+        )
+
+        loaded_emb, loaded_ref, loaded_tldrs = self.store.load_researcher_enrichment(
+            "alice smith"
+        )
+        assert len(loaded_emb) == 2
+        assert len(loaded_emb["p1"]) == 768
+        assert loaded_ref == ref_map
+        assert loaded_tldrs == tldrs
+
+    def test_enrichment_empty_when_not_cached(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        emb, refs, tldrs = self.store.load_researcher_enrichment("alice smith")
+        assert emb == {}
+        assert refs == {}
+        assert tldrs == {}
+
+    def test_enrichment_upsert_overwrites(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        self.store.save_enrichment("alice smith", "tldrs", {"p1": "old"})
+        self.store.save_enrichment("alice smith", "tldrs", {"p1": "new"})
+
+        loaded = self.store.load_enrichment("alice smith", "tldrs")
+        assert loaded == {"p1": "new"}
+
+    def test_enrichment_cascades_on_delete(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+        self.store.save_researcher_enrichment(
+            "alice smith", embeddings={"p1": [0.1]},
+        )
+
+        self.store.delete_researcher("alice smith")
+
+        emb, refs, tldrs = self.store.load_researcher_enrichment("alice smith")
+        assert emb == {}
+
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+
+class TestResearcherStoreMigration:
+    def test_migration_adds_columns_to_existing_db(self):
+        """Simulate an old DB without enrichment columns and verify migration."""
+        tmpdir = tempfile.mkdtemp()
+        db_path = f"{tmpdir}/old.sqlite"
+
+        # Create old-style DB without enrichment columns
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE researchers (
+                normalized_name TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                openalex_id TEXT,
+                semantic_scholar_id TEXT,
+                affiliations TEXT,
+                works_count INTEGER DEFAULT 0,
+                citations_count INTEGER DEFAULT 0,
+                h_index INTEGER,
+                fields TEXT,
+                lookup_timestamp TEXT,
+                updated_at TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE researcher_papers (
+                researcher_name TEXT NOT NULL,
+                paper_id TEXT NOT NULL,
+                title TEXT, year INTEGER, citation_count INTEGER,
+                venue TEXT, doi TEXT, abstract TEXT, fields TEXT, source TEXT,
+                PRIMARY KEY (researcher_name, paper_id),
+                FOREIGN KEY (researcher_name) REFERENCES researchers(normalized_name) ON DELETE CASCADE
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE researcher_web_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                researcher_name TEXT NOT NULL,
+                title TEXT, url TEXT, snippet TEXT,
+                FOREIGN KEY (researcher_name) REFERENCES researchers(normalized_name) ON DELETE CASCADE
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Now open with ResearcherStore — should migrate
+        store = ResearcherStore(path=db_path)
+
+        # Verify columns exist
+        conn = sqlite3.connect(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(researcher_papers)").fetchall()}
+        conn.close()
+        assert "oa_status" in cols
+        assert "open_access_url" in cols
+        assert "tldr" in cols
+
+        # Verify enrichment table exists
+        conn = sqlite3.connect(db_path)
+        tables = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        conn.close()
+        assert "researcher_enrichment" in tables
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    def test_graph_works_without_enrichment(self):
+        """Graph builder produces a valid graph even with no cached enrichment."""
+        gb = GraphBuilder()
+        profile = _make_profile()
+        gb.add_researcher(profile.to_dict())
+        for p in profile.top_papers:
+            pid = gb.add_paper(p)
+            gb.add_authorship_edge("researcher:A111", pid)
+        gb.build_structural_context()
+        # No enrichment injection — should still produce valid graph
+        data = gb.to_dict()
+        assert len(data["nodes"]) > 0
+        assert len(data["links"]) > 0
+
+    def test_inject_with_empty_enrichment(self):
+        """Injecting empty dicts is a no-op."""
+        gb = GraphBuilder()
+        profile = _make_profile()
+        gb.add_researcher(profile.to_dict())
+        for p in profile.top_papers:
+            pid = gb.add_paper(p)
+            gb.add_authorship_edge("researcher:A111", pid)
+        gb.build_structural_context()
+
+        # Empty dicts — should do nothing
+        gb.inject_embeddings({})
+        gb.inject_tldrs({})
+        gb.fill_citation_gaps({})
+
+        data = gb.to_dict()
+        assert len(data["nodes"]) > 0
+        # No semantic edges should exist
+        semantic_edges = [e for e in data["links"] if e.get("type") == "semantic"]
+        assert len(semantic_edges) == 0

--- a/tests/test_graph_builder_enrichment.py
+++ b/tests/test_graph_builder_enrichment.py
@@ -1,0 +1,203 @@
+"""Tests for researcher profile enrichment in GraphBuilder.build_from_kb_papers()."""
+
+import pytest
+
+from research_agent.explorer.graph_builder import GraphBuilder
+
+
+def _make_papers(researcher="Alice Smith", count=2):
+    """Create minimal KB paper dicts for testing."""
+    return [
+        {
+            "paper_id": f"paper_{i}",
+            "title": f"Paper {i} by {researcher}",
+            "researcher": researcher,
+            "fields": ["Sociology", "Urban Studies"],
+            "citation_count": 10 * (i + 1),
+        }
+        for i in range(count)
+    ]
+
+
+class _MockProfile:
+    """Mimics ResearcherProfile.to_dict() without importing the real class."""
+
+    def __init__(self, **kwargs):
+        self._data = kwargs
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _MockRegistry:
+    """Mimics ResearcherRegistry.get(name) with a dict of profiles."""
+
+    def __init__(self, profiles: dict[str, _MockProfile]):
+        self._profiles = {k.lower().strip(): v for k, v in profiles.items()}
+
+    def get(self, name):
+        return self._profiles.get(name.lower().strip())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFromKbPapersWithoutRegistry:
+    def test_researcher_node_has_minimal_data(self):
+        gb = GraphBuilder()
+        papers = _make_papers("Alice Smith", count=2)
+        gb.build_from_kb_papers(papers, researcher_registry=None)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["label"] == "Alice Smith"
+        assert node["metadata"]["h_index"] is None
+        assert node["metadata"]["affiliations"] == []
+        assert node["id"] == "researcher:Alice Smith"
+
+
+class TestBuildFromKbPapersWithRegistryEnriches:
+    def test_enriched_node_has_full_profile(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id="S222",
+            h_index=25,
+            affiliations=["MIT"],
+            works_count=100,
+            citations_count=5000,
+            fields=["Sociology", "Geography"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        gb = GraphBuilder()
+        papers = _make_papers("Alice Smith", count=2)
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["metadata"]["h_index"] == 25
+        assert node["metadata"]["affiliations"] == ["MIT"]
+        assert node["id"] == "researcher:A111"
+        assert node["metadata"]["works_count"] == 100
+        assert node["metadata"]["citations"] == 5000
+
+
+class TestBuildFromKbPapersGracefulDegradation:
+    def test_unknown_researcher_gets_minimal_node(self):
+        registry = _MockRegistry({})  # empty — no profiles
+
+        gb = GraphBuilder()
+        papers = _make_papers("Bob Unknown", count=1)
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["label"] == "Bob Unknown"
+        assert node["metadata"]["h_index"] is None
+        assert node["id"] == "researcher:Bob Unknown"
+
+
+class TestBuildFromKbPapersMixedEnrichment:
+    def test_one_enriched_one_minimal(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=25,
+            affiliations=["MIT"],
+            works_count=50,
+            citations_count=2000,
+            fields=["Sociology"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        papers = _make_papers("Alice Smith", count=1) + _make_papers("Bob Unknown", count=1)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        nodes_by_label = {n["label"]: n for n in data["nodes"] if n["type"] == "researcher"}
+        assert nodes_by_label["Alice Smith"]["metadata"]["h_index"] == 25
+        assert nodes_by_label["Bob Unknown"]["metadata"]["h_index"] is None
+
+
+class TestWorksCountUsesMax:
+    def test_registry_count_wins_when_larger(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=100,
+            citations_count=5000,
+            fields=[],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        # KB has 2 papers with 10+20=30 citations
+        papers = _make_papers("Alice Smith", count=2)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        assert node["metadata"]["works_count"] == 100  # registry wins
+        assert node["metadata"]["citations"] == 5000   # registry wins
+
+    def test_kb_count_wins_when_larger(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=1,       # registry has less
+            citations_count=5,   # registry has less
+            fields=[],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        papers = _make_papers("Alice Smith", count=2)  # 2 papers, 30 total cites
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        assert node["metadata"]["works_count"] == 2   # KB wins
+        assert node["metadata"]["citations"] == 30     # KB wins
+
+
+class TestFieldsMergedAndDeduplicated:
+    def test_fields_merged_without_dupes(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=0,
+            citations_count=0,
+            fields=["Sociology", "Tourism", "Geography"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        # KB papers have ["Sociology", "Urban Studies"]
+        papers = _make_papers("Alice Smith", count=1)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        fields = node["metadata"]["fields"]
+        # KB fields first, then registry additions (no dupes)
+        assert fields == ["Sociology", "Urban Studies", "Tourism", "Geography"]

--- a/tests/test_multi_model_pipeline.py
+++ b/tests/test_multi_model_pipeline.py
@@ -1,0 +1,339 @@
+"""
+Tests for the multi-model pipeline feature.
+
+Covers:
+- configure_pipeline accepts valid task types
+- configure_pipeline filters invalid task types
+- task_infer with no pipeline (uses default model)
+- task_infer with pipeline override (switches model)
+- task_infer restores original model after override
+- task_infer restores original model even on error
+- Pipeline config loading from YAML
+- resolve_pipeline_aliases with known and unknown providers
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_model_loading():
+    """Prevent actual model loading in tests."""
+    from research_agent.models.llm_utils import VRAMConstraintError
+
+    with patch("research_agent.agents.research_agent.get_qlora_pipeline") as mock_qlora, \
+         patch("research_agent.agents.research_agent.get_ollama_pipeline") as mock_ollama:
+        mock_qlora.side_effect = VRAMConstraintError("Model loading disabled in tests")
+        mock_ollama.side_effect = Exception("Ollama disabled in tests")
+        yield
+
+
+def _make_agent(**kwargs):
+    """Create a minimal ResearchAgent for testing."""
+    from research_agent.agents.research_agent import ResearchAgent
+    return ResearchAgent(use_ollama=False, **kwargs)
+
+
+def _make_agent_with_model():
+    """Create a ResearchAgent with a mocked OpenAI-compatible model."""
+    from research_agent.agents.research_agent import ResearchAgent
+
+    agent = ResearchAgent(use_ollama=False)
+
+    # Inject a mock model that supports switch_model
+    mock_model = MagicMock()
+    mock_model.model_name = "default-model"
+    mock_model.generate.return_value = "mock response"
+    mock_model.switch_model = MagicMock()
+    mock_model.list_available_models.return_value = [
+        "default-model", "fast-model", "big-model",
+    ]
+
+    agent.model = mock_model
+    agent.provider = "openai"
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# configure_pipeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestConfigurePipeline:
+
+    def test_accepts_valid_task_types(self):
+        agent = _make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        })
+        assert agent._pipeline == {
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        }
+
+    def test_filters_invalid_task_types(self):
+        agent = _make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "summarize": "some-model",       # invalid
+            "translate": "some-model",       # invalid
+        })
+        assert "classify" in agent._pipeline
+        assert "summarize" not in agent._pipeline
+        assert "translate" not in agent._pipeline
+
+    def test_empty_pipeline(self):
+        agent = _make_agent()
+        agent.configure_pipeline({})
+        assert agent._pipeline == {}
+
+    def test_partial_pipeline(self):
+        agent = _make_agent()
+        agent.configure_pipeline({"synthesize": "big-model"})
+        assert agent._pipeline == {"synthesize": "big-model"}
+        assert "classify" not in agent._pipeline
+
+    def test_warns_for_unknown_model(self):
+        """configure_pipeline should log a warning for unknown models."""
+        agent = _make_agent_with_model()
+        with patch("research_agent.agents.research_agent.logger") as mock_logger:
+            agent.configure_pipeline({"classify": "nonexistent-model"})
+            # Should have at least one warning about the unknown model
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "nonexistent-model" in str(c)
+            ]
+            assert len(warning_calls) >= 1
+
+    def test_no_warning_for_known_model(self):
+        """configure_pipeline should not warn for models in the known list."""
+        agent = _make_agent_with_model()
+        with patch("research_agent.agents.research_agent.logger") as mock_logger:
+            agent.configure_pipeline({"classify": "fast-model"})
+            # Should NOT have warnings about unknown models
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "not in known model" in str(c)
+            ]
+            assert len(warning_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# task_infer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestTaskInfer:
+
+    def test_no_pipeline_uses_default(self):
+        """With no pipeline configured, task_infer uses the default model."""
+        agent = _make_agent_with_model()
+        # No pipeline set -> _pipeline is empty
+        result = agent.task_infer("classify", "test prompt")
+        assert result == "mock response"
+        # switch_model should NOT be called
+        agent.model.switch_model.assert_not_called()
+
+    def test_pipeline_override_switches_model(self):
+        """With a pipeline override, task_infer switches to the specified model."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+
+        result = agent.task_infer("classify", "test prompt")
+        assert result == "mock response"
+
+        # Should have switched to fast-model, then back to default-model
+        calls = agent.model.switch_model.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0] == "fast-model"
+        assert calls[1].args[0] == "default-model"
+
+    def test_restores_original_model_after_override(self):
+        """After task_infer with override, the model is restored to the original."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"synthesize": "big-model"})
+
+        agent.task_infer("synthesize", "test prompt")
+
+        # Last call should restore to default-model
+        last_call = agent.model.switch_model.call_args_list[-1]
+        assert last_call.args[0] == "default-model"
+
+    def test_restores_model_on_error(self):
+        """Even if generate() raises, the model must be restored."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+        agent.model.generate.side_effect = RuntimeError("LLM failure")
+
+        # task_infer calls infer() which catches general exceptions
+        result = agent.task_infer("classify", "test prompt")
+        assert "Error" in result or "error" in result.lower()
+
+        # Model should still be restored to default
+        last_call = agent.model.switch_model.call_args_list[-1]
+        assert last_call.args[0] == "default-model"
+
+    def test_unmatched_task_uses_default(self):
+        """A task not in the pipeline should use the default model."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+
+        # "synthesize" is NOT in the pipeline
+        agent.task_infer("synthesize", "test prompt")
+        agent.model.switch_model.assert_not_called()
+
+    def test_no_model_returns_inference_result(self):
+        """With no model at all, task_infer should still return something."""
+        agent = _make_agent()
+        # agent.model is None (no LLM loaded)
+        result = agent.task_infer("classify", "test prompt")
+        # Should hit the infer() error handling path
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# resolve_pipeline_aliases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestResolvePipelineAliases:
+
+    def test_resolves_fast_alias_for_groq(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "groq",
+        )
+        assert result["classify"] == "llama-3.1-8b-instant"
+        assert result["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_resolves_fast_alias_for_openai(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "openai",
+        )
+        assert result["classify"] == "gpt-4o-mini"
+        assert result["synthesize"] == "gpt-4o"
+
+    def test_resolves_fast_alias_for_anthropic(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "anthropic",
+        )
+        assert result["classify"] == "claude-haiku-4-5"
+        assert result["synthesize"] == "claude-sonnet-4-6"
+
+    def test_literal_model_name_passes_through(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "my-custom-model", "synthesize": "another-model"},
+            "groq",
+        )
+        assert result["classify"] == "my-custom-model"
+        assert result["synthesize"] == "another-model"
+
+    def test_unknown_provider_passes_through(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "unknown_provider",
+        )
+        # No aliases known for unknown provider, so values pass through
+        assert result["classify"] == "fast"
+        assert result["synthesize"] == "default"
+
+    def test_mixed_aliases_and_literals(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "extract_keywords": "my-model", "synthesize": "default"},
+            "groq",
+        )
+        assert result["classify"] == "llama-3.1-8b-instant"
+        assert result["extract_keywords"] == "my-model"
+        assert result["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_empty_pipeline(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases({}, "groq")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline config loading from YAML
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestPipelineConfigLoading:
+
+    def test_pipeline_loaded_from_yaml(self, tmp_path):
+        """Pipeline section in YAML should be loadable and resolvable."""
+        from research_agent.utils.config import load_config
+        from research_agent.main import resolve_pipeline_aliases
+
+        cfg_file = tmp_path / "test_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+            "  pipeline:\n"
+            "    classify: fast\n"
+            "    extract_keywords: fast\n"
+            "    synthesize: default\n"
+        )
+
+        config = load_config(str(cfg_file))
+        model_cfg = config.get("model", {})
+        pipeline_cfg = model_cfg.get("pipeline")
+
+        assert pipeline_cfg is not None
+        assert isinstance(pipeline_cfg, dict)
+        assert pipeline_cfg["classify"] == "fast"
+
+        resolved = resolve_pipeline_aliases(pipeline_cfg, "groq")
+        assert resolved["classify"] == "llama-3.1-8b-instant"
+        assert resolved["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_no_pipeline_section(self, tmp_path):
+        """Config without pipeline section should not break anything."""
+        from research_agent.utils.config import load_config
+
+        cfg_file = tmp_path / "no_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+        )
+
+        config = load_config(str(cfg_file))
+        model_cfg = config.get("model", {})
+        pipeline_cfg = model_cfg.get("pipeline")
+
+        assert pipeline_cfg is None
+
+    def test_pipeline_with_literal_model_names(self, tmp_path):
+        """Pipeline with literal model names (no aliases) should pass through."""
+        from research_agent.utils.config import load_config
+        from research_agent.main import resolve_pipeline_aliases
+
+        cfg_file = tmp_path / "literal_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+            "  pipeline:\n"
+            "    classify: llama-3.1-8b-instant\n"
+            "    synthesize: llama-3.3-70b-versatile\n"
+        )
+
+        config = load_config(str(cfg_file))
+        pipeline_cfg = config["model"]["pipeline"]
+
+        resolved = resolve_pipeline_aliases(pipeline_cfg, "groq")
+        assert resolved["classify"] == "llama-3.1-8b-instant"
+        assert resolved["synthesize"] == "llama-3.3-70b-versatile"

--- a/tests/test_perplexity_integration.py
+++ b/tests/test_perplexity_integration.py
@@ -1,0 +1,368 @@
+"""
+Tests for Perplexity integration: LLM provider config and web search provider.
+
+All HTTP calls are mocked -- no real API key needed.
+"""
+
+import asyncio
+import os
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from research_agent.tools.web_search import (
+    WebSearchTool,
+    WebResult,
+    _extract_citation_snippet,
+    _title_from_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PERPLEXITY_RESPONSE = {
+    "id": "chatcmpl-test-123",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": (
+                    "According to recent research [1], climate change has "
+                    "significant impacts on Arctic ecosystems. Studies show [2] "
+                    "that permafrost thawing accelerates greenhouse gas release. "
+                    "Furthermore [3], indigenous communities are adapting their "
+                    "practices in response to these changes."
+                ),
+            }
+        }
+    ],
+    "citations": [
+        "https://example.com/arctic-climate-study",
+        "https://nature.com/permafrost-thawing-2024",
+        "https://indigenous-voices.org/adaptation-report",
+    ],
+}
+
+
+PERPLEXITY_RESPONSE_NO_CITATIONS = {
+    "id": "chatcmpl-test-456",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "Climate change affects many regions worldwide.",
+            }
+        }
+    ],
+    # No citations field at all
+}
+
+
+PERPLEXITY_RESPONSE_EMPTY_CITATIONS = {
+    "id": "chatcmpl-test-789",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "Some general information about the topic.",
+            }
+        }
+    ],
+    "citations": [],
+}
+
+
+def _make_mock_response(data: dict, status_code: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response from a dict."""
+    response = httpx.Response(
+        status_code=status_code,
+        json=data,
+        request=httpx.Request("POST", "https://api.perplexity.ai/chat/completions"),
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# 1. CLOUD_PROVIDERS config
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityCloudProvider:
+    """Verify perplexity entry in CLOUD_PROVIDERS."""
+
+    def test_perplexity_in_cloud_providers(self):
+        from research_agent.main import CLOUD_PROVIDERS
+
+        assert "perplexity" in CLOUD_PROVIDERS
+
+    def test_perplexity_provider_fields(self):
+        from research_agent.main import CLOUD_PROVIDERS
+
+        cfg = CLOUD_PROVIDERS["perplexity"]
+        assert cfg["name"] == "Perplexity AI"
+        assert cfg["base_url"] == "https://api.perplexity.ai"
+        assert cfg["api_key_env"] == "PERPLEXITY_API_KEY"
+        assert cfg["default_model"] == "sonar"
+        assert "sonar" in cfg["models"]
+        assert "sonar-pro" in cfg["models"]
+        assert "sonar-reasoning" in cfg["models"]
+
+    def test_perplexity_in_auto_detection_order(self):
+        """Perplexity should be checked after groq but before openrouter."""
+        from research_agent.main import detect_available_provider
+
+        # With only PERPLEXITY_API_KEY set, it should be selected
+        env = {"PERPLEXITY_API_KEY": "pplx-test-key"}
+        with patch.dict(os.environ, env, clear=False):
+            # Clear other keys that might take priority
+            for key in ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GROQ_API_KEY"]:
+                os.environ.pop(key, None)
+            provider, cfg = detect_available_provider({})
+            assert provider == "perplexity"
+            assert cfg["name"] == "Perplexity AI"
+
+
+# ---------------------------------------------------------------------------
+# 2. WebSearchTool provider selection
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityProviderSelection:
+    """Verify perplexity is accepted as a web search provider."""
+
+    def test_create_with_perplexity_provider(self):
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+        assert tool.provider == "perplexity"
+        assert tool.api_key == "pplx-test"
+
+    def test_search_dispatches_to_perplexity(self):
+        """search() should call _search_perplexity for perplexity provider."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+        mock = AsyncMock(return_value=[])
+        tool._search_perplexity = mock
+
+        asyncio.get_event_loop().run_until_complete(
+            tool.search("test query")
+        )
+        mock.assert_called_once_with("test query", 10)
+
+
+# ---------------------------------------------------------------------------
+# 3. _search_perplexity() with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPerplexity:
+    """Test the _search_perplexity method with mocked API calls."""
+
+    def test_missing_api_key_raises(self):
+        tool = WebSearchTool(api_key=None, provider="perplexity")
+        with pytest.raises(ValueError, match="Perplexity API key required"):
+            asyncio.get_event_loop().run_until_complete(
+                tool._search_perplexity("test query", max_results=10)
+            )
+
+    def test_successful_search_with_citations(self):
+        """Normal response with citations returns WebResult per citation."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("Arctic climate change", max_results=10)
+        )
+
+        assert len(results) == 3
+        assert all(isinstance(r, WebResult) for r in results)
+
+        # First result
+        assert results[0].url == "https://example.com/arctic-climate-study"
+        assert results[0].content  # should have snippet text
+        assert results[0].raw_content is not None  # first result gets raw_content
+
+        # Second result
+        assert results[1].url == "https://nature.com/permafrost-thawing-2024"
+        assert results[1].raw_content is None  # only first gets raw_content
+
+        # Third result
+        assert results[2].url == "https://indigenous-voices.org/adaptation-report"
+
+    def test_max_results_limits_citations(self):
+        """When max_results < len(citations), only that many are returned."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("test", max_results=2)
+        )
+
+        assert len(results) == 2
+
+    def test_no_citations_returns_single_result(self):
+        """Response without citations wraps whole answer as one WebResult."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE_NO_CITATIONS)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("climate change effects", max_results=10)
+        )
+
+        assert len(results) == 1
+        assert results[0].url == ""
+        assert "Climate change" in results[0].content
+        assert results[0].raw_content is not None
+
+    def test_empty_citations_returns_single_result(self):
+        """Response with empty citations list wraps whole answer."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE_EMPTY_CITATIONS)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("topic info", max_results=10)
+        )
+
+        assert len(results) == 1
+        assert results[0].url == ""
+
+    def test_http_error_returns_empty(self):
+        """HTTP errors should return empty list, not crash."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response({}, status_code=500)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("test query", max_results=10)
+        )
+
+        assert results == []
+
+    def test_request_format(self):
+        """Verify the request is sent with correct headers and body."""
+        tool = WebSearchTool(api_key="pplx-secret-key", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("my query", max_results=10)
+        )
+
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "https://api.perplexity.ai/chat/completions"
+        headers = call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer pplx-secret-key"
+        assert headers["Content-Type"] == "application/json"
+        body = call_args[1]["json"]
+        assert body["model"] == "sonar"
+        assert body["messages"][0]["content"] == "Search: my query"
+
+
+# ---------------------------------------------------------------------------
+# 4. Citation extraction helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCitationHelpers:
+    """Test the helper functions for citation parsing."""
+
+    def test_extract_citation_snippet_found(self):
+        content = "Climate change is real [1] and affects everyone [2] globally."
+        snippet = _extract_citation_snippet(content, "[1]", context_chars=20)
+        assert "[1]" in snippet
+        assert len(snippet) > 0
+
+    def test_extract_citation_snippet_not_found(self):
+        content = "No citations here."
+        snippet = _extract_citation_snippet(content, "[5]")
+        assert snippet == ""
+
+    def test_extract_citation_snippet_at_start(self):
+        content = "[1] This is the first point."
+        snippet = _extract_citation_snippet(content, "[1]", context_chars=50)
+        assert "[1]" in snippet
+
+    def test_title_from_url_with_path(self):
+        title = _title_from_url("https://www.example.com/articles/my-great-article")
+        assert "my great article" in title
+        assert "example.com" in title
+
+    def test_title_from_url_no_path(self):
+        title = _title_from_url("https://example.com/")
+        assert "example.com" in title
+
+    def test_title_from_url_long_slug(self):
+        long_slug = "a-very-" + "long-" * 20 + "title"
+        title = _title_from_url(f"https://example.com/{long_slug}")
+        assert len(title) < 100  # should be truncated
+
+    def test_title_from_url_invalid(self):
+        title = _title_from_url("not-a-url")
+        # Should not crash
+        assert isinstance(title, str)
+
+
+# ---------------------------------------------------------------------------
+# 5. Initialization in main.py
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityWebSearchInit:
+    """Verify that main.py wires up perplexity web search correctly."""
+
+    def test_perplexity_api_key_loaded(self):
+        """When provider is perplexity, PERPLEXITY_API_KEY should be used."""
+        config = {
+            "model": {"provider": "none"},
+            "search": {
+                "web_search": {
+                    "enabled": True,
+                    "provider": "perplexity",
+                }
+            },
+        }
+
+        with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pplx-from-env"}):
+            # Import and test the web search init logic
+            from research_agent.main import build_agent_from_config
+
+            # We can't easily run build_agent_from_config without all deps,
+            # so test the config parsing logic directly
+            search_cfg = config.get("search", {})
+            web_cfg = search_cfg.get("web_search", {}) or {}
+            web_provider = web_cfg.get("provider", "duckduckgo")
+            web_api_key = None
+            if web_provider == "tavily":
+                web_api_key = os.getenv("TAVILY_API_KEY")
+            elif web_provider == "serper":
+                web_api_key = os.getenv("SERPER_API_KEY")
+            elif web_provider == "perplexity":
+                web_api_key = os.getenv("PERPLEXITY_API_KEY")
+
+            assert web_provider == "perplexity"
+            assert web_api_key == "pplx-from-env"

--- a/tests/test_pipeline_ui.py
+++ b/tests/test_pipeline_ui.py
@@ -1,0 +1,120 @@
+"""Tests for pipeline model configuration logic."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestConfigurePipelineFromUI:
+    """Test the pipeline dict construction from UI dropdown values."""
+
+    def _build_pipeline(self, classify, keywords, synthesize):
+        """Replicate the UI handler logic for building pipeline dict."""
+        pipeline = {}
+        if classify and classify != "default":
+            pipeline["classify"] = classify
+        if keywords and keywords != "default":
+            pipeline["extract_keywords"] = keywords
+        if synthesize and synthesize != "default":
+            pipeline["synthesize"] = synthesize
+        return pipeline
+
+    def test_all_default(self):
+        """All 'default' → empty pipeline dict."""
+        result = self._build_pipeline("default", "default", "default")
+        assert result == {}
+
+    def test_fast_classify(self):
+        """Only classify overridden."""
+        result = self._build_pipeline("llama-3.1-8b-instant", "default", "default")
+        assert result == {"classify": "llama-3.1-8b-instant"}
+
+    def test_all_overridden(self):
+        """All three tasks overridden."""
+        result = self._build_pipeline(
+            "gpt-4o-mini", "gpt-4o-mini", "gpt-4o"
+        )
+        assert result == {
+            "classify": "gpt-4o-mini",
+            "extract_keywords": "gpt-4o-mini",
+            "synthesize": "gpt-4o",
+        }
+
+    def test_empty_string_treated_as_default(self):
+        """Empty string → not included in pipeline."""
+        result = self._build_pipeline("", "default", "gpt-4o")
+        assert result == {"synthesize": "gpt-4o"}
+
+    def test_none_treated_as_default(self):
+        """None → not included in pipeline."""
+        result = self._build_pipeline(None, None, None)
+        assert result == {}
+
+
+class TestPipelineChoices:
+    """Test pipeline dropdown choices construction."""
+
+    def test_choices_include_default(self):
+        """'default' is always first in choices."""
+        models = ["gpt-4o-mini", "gpt-4o"]
+        choices = ["default"] + models
+        assert choices[0] == "default"
+        assert len(choices) == 3
+
+    def test_choices_with_no_models(self):
+        """When no models available, only 'default'."""
+        models = []
+        choices = ["default"] + models if models else ["default"]
+        assert choices == ["default"]
+
+
+@pytest.fixture(autouse=True)
+def mock_model_loading():
+    """Prevent actual model loading."""
+    from research_agent.models.llm_utils import VRAMConstraintError
+
+    with patch("research_agent.agents.research_agent.get_qlora_pipeline") as mock_qlora, \
+         patch("research_agent.agents.research_agent.get_ollama_pipeline") as mock_ollama:
+        mock_qlora.side_effect = VRAMConstraintError("disabled in tests")
+        mock_ollama.side_effect = Exception("disabled in tests")
+        yield
+
+
+class TestAgentConfigurePipeline:
+    """Test that agent.configure_pipeline() works with UI-style dicts."""
+
+    def _make_agent(self):
+        from research_agent.agents.research_agent import ResearchAgent
+        return ResearchAgent(
+            vector_store=MagicMock(),
+            embedder=MagicMock(),
+            use_ollama=False,
+        )
+
+    def test_valid_tasks_accepted(self):
+        """Valid task types are stored."""
+        agent = self._make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        })
+        assert agent._pipeline["classify"] == "fast-model"
+        assert agent._pipeline["synthesize"] == "big-model"
+
+    def test_empty_pipeline_clears(self):
+        """Empty dict clears all overrides."""
+        agent = self._make_agent()
+        agent.configure_pipeline({"classify": "fast"})
+        assert len(agent._pipeline) == 1
+        agent.configure_pipeline({})
+        assert len(agent._pipeline) == 0
+
+    def test_unknown_tasks_ignored(self):
+        """Unknown task types are silently filtered out."""
+        agent = self._make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "unknown_task": "some-model",
+        })
+        assert "classify" in agent._pipeline
+        assert "unknown_task" not in agent._pipeline

--- a/tests/test_web_search_switch.py
+++ b/tests/test_web_search_switch.py
@@ -1,0 +1,43 @@
+"""Tests for WebSearchTool provider switching."""
+
+import pytest
+from research_agent.tools.web_search import WebSearchTool
+
+
+class TestSetProvider:
+    def test_switch_to_perplexity(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("perplexity", api_key="pplx-test")
+        assert tool.provider == "perplexity"
+        assert tool.api_key == "pplx-test"
+
+    def test_switch_to_duckduckgo(self):
+        tool = WebSearchTool(provider="perplexity", api_key="key")
+        tool.set_provider("duckduckgo")
+        assert tool.provider == "duckduckgo"
+
+    def test_switch_to_tavily(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("tavily", api_key="tvly-test")
+        assert tool.provider == "tavily"
+
+    def test_switch_to_serper(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("serper", api_key="serp-test")
+        assert tool.provider == "serper"
+
+    def test_invalid_provider_raises(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        with pytest.raises(ValueError, match="Unknown provider"):
+            tool.set_provider("google")
+
+    def test_api_key_preserved_when_not_provided(self):
+        tool = WebSearchTool(provider="tavily", api_key="original-key")
+        tool.set_provider("perplexity")
+        # api_key unchanged since we didn't pass a new one
+        assert tool.api_key == "original-key"
+
+    def test_api_key_updated_when_provided(self):
+        tool = WebSearchTool(provider="tavily", api_key="old-key")
+        tool.set_provider("perplexity", api_key="new-key")
+        assert tool.api_key == "new-key"


### PR DESCRIPTION
## Summary

- **Web search provider switching**: Runtime dropdown in Retrieval Settings for DuckDuckGo/Perplexity/Tavily/Serper with API key detection and status feedback
- **Multi-model pipeline UI**: Per-task model assignment (classify/keywords/synthesize) via accordion dropdowns, auto-populated from available models
- **CORE API integration**: Search 300M+ open access papers via CORE v3 API, integrated into external search pipeline alongside OpenAlex and S2, toggleable via UI checkbox
- Backend foundations: Perplexity as LLM+search provider, pipeline alias resolution with provider-aware defaults, enrichment caching for researcher profiles

Completes 3 high-priority roadmap items. 310 tests passing (24 new across 3 test files, 7 new test files total).

## Test plan

- [ ] `uv run pytest tests/test_web_search_switch.py -v` — provider switching
- [ ] `uv run pytest tests/test_pipeline_ui.py -v` — pipeline config from UI values
- [ ] `uv run pytest tests/test_core_search.py -v` — CORE search with mocked httpx
- [ ] `uv run pytest tests/test_perplexity_integration.py -v` — Perplexity provider
- [ ] `uv run pytest tests/test_multi_model_pipeline.py -v` — pipeline aliases + task_infer
- [ ] `uv run pytest tests/ -x -q` — full suite green (310 passed)
- [ ] Manual: Retrieval Settings → switch web search to Perplexity → verify status
- [ ] Manual: Pipeline Models accordion → assign models → verify in logs
- [ ] Manual: CORE checkbox toggle → verify in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)