### PR TITLE
feat: native Claude tool use — smart agent routing

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -10,6 +10,7 @@ model:
   # - "openai" - OpenAI API (requires OPENAI_API_KEY)
   # - "anthropic" - Anthropic Claude (requires ANTHROPIC_API_KEY)
   # - "groq" - Groq API with free tier (requires GROQ_API_KEY)
+  # - "perplexity" - Perplexity AI with web-grounded models (requires PERPLEXITY_API_KEY)
   # - "openrouter" - OpenRouter with free models (requires OPENROUTER_API_KEY)
   # - "ollama" - Local Ollama server
   # - "huggingface" - Local HuggingFace models (requires GPU)
@@ -20,10 +21,11 @@ model:
   # 1. OPENAI_API_KEY -> use OpenAI
   # 2. ANTHROPIC_API_KEY -> use Anthropic (Claude)
   # 3. GROQ_API_KEY -> use Groq (free tier!)
-  # 4. OPENROUTER_API_KEY -> use OpenRouter (has free models)
-  # 5. Ollama server -> use Ollama if running
-  # 6. GPU available -> use HuggingFace
-  # 7. Nothing -> retrieval-only mode (still works!)
+  # 4. PERPLEXITY_API_KEY -> use Perplexity AI
+  # 5. OPENROUTER_API_KEY -> use OpenRouter (has free models)
+  # 6. Ollama server -> use Ollama if running
+  # 7. GPU available -> use HuggingFace
+  # 8. Nothing -> retrieval-only mode (still works!)
 
   provider: "groq"
 
@@ -129,8 +131,8 @@ search:
   # Web search for grey literature
   web_search:
     enabled: true
-    provider: "duckduckgo"  # "duckduckgo" (free, no key), "tavily", or "serper"
-    # API key loaded from environment: TAVILY_API_KEY or SERPER_API_KEY
+    provider: "duckduckgo"  # "duckduckgo" (free, no key), "tavily", "serper", or "perplexity"
+    # API key loaded from environment: TAVILY_API_KEY, SERPER_API_KEY, or PERPLEXITY_API_KEY
 
 # ============================================
 # Knowledge Base Ingestion

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -43,10 +43,32 @@ model:
   # Multi-model pipeline: assign different models per task type.
   # If unset, every task uses the default model above.
   # Task types: classify, extract_keywords, synthesize
-  # pipeline:
-  #   classify: "llama-3.1-8b-instant"          # fast/cheap for classification
-  #   extract_keywords: "llama-3.1-8b-instant"   # fast for keyword extraction
-  #   synthesize: "llama-3.3-70b-versatile"      # capable for synthesis
+  #
+  # Use "fast" or "default" aliases — they resolve to the active provider's
+  # recommended models automatically (see PROVIDER_PIPELINE_DEFAULTS in main.py).
+  # Or specify literal model names for full control.
+  pipeline:
+    classify: "fast"              # cheap/fast model for classification
+    extract_keywords: "fast"      # cheap/fast model for keyword extraction
+    synthesize: "default"         # main capable model for synthesis
+  #
+  # Provider-specific examples (literal model names):
+  # Groq free tier:
+  #   classify: "llama-3.1-8b-instant"
+  #   extract_keywords: "llama-3.1-8b-instant"
+  #   synthesize: "llama-3.3-70b-versatile"
+  # OpenAI:
+  #   classify: "gpt-4o-mini"
+  #   extract_keywords: "gpt-4o-mini"
+  #   synthesize: "gpt-4o"
+  # Anthropic:
+  #   classify: "claude-haiku-4-5"
+  #   extract_keywords: "claude-haiku-4-5"
+  #   synthesize: "claude-sonnet-4-6"
+  # Ollama:
+  #   classify: "llama3.2:3b"
+  #   extract_keywords: "llama3.2:3b"
+  #   synthesize: "qwen3:32b"
 
   # OpenAI settings (provider: "openai")
   openai:

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -150,6 +150,11 @@ search:
     enabled: true
     email: null  # Optional: for polite pool
     
+  core:
+    enabled: true
+    # CORE_API_KEY env var. Free tier works without key.
+    api_key: null
+
   # Web search for grey literature
   web_search:
     enabled: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Implementation history for the Research Agent project.
 
+## February 24, 2026
+- **Researcher ↔ KB Paper Linking** — auto-link KB papers to known researchers on ingestion and lookup; `update_paper_metadata()` dual-write in VectorStore; `match_author_name()` in ResearcherRegistry; `researcher_linker` module for full-scan and targeted linking
+- **Researchers Browser** — new accordion in KB tab: table with Name/Affiliation/Registry Papers/KB Papers/Citations/h-index, Re-link button, delete by name
+- **Duplicate wiring fix** — merged two `papers_table.select` bindings into one (was firing `select_kb_paper_with_context` twice per click)
+- **13 new tests** for researcher persistence (SQLite methods, name matching, auto-linking, idempotency)
+
 ## February 22, 2026
 - **SQLite Metadata Index** — dual-write/delegated-read layer (`KBMetadataStore`) alongside ChromaDB; `list_papers()`, `get_stats()`, `list_notes()` now hit SQLite instead of scanning all chunks ([rationale](STORAGE_PHILOSOPHY.md))
 - **Auto-rebuild** — if SQLite index is empty but ChromaDB has data, rebuilds automatically on startup

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,11 @@ Implementation history for the Research Agent project.
 - **Researchers Browser** — new accordion in KB tab: table with Name/Affiliation/Registry Papers/KB Papers/Citations/h-index, Re-link button, delete by name
 - **Duplicate wiring fix** — merged two `papers_table.select` bindings into one (was firing `select_kb_paper_with_context` twice per click)
 - **13 new tests** for researcher persistence (SQLite methods, name matching, auto-linking, idempotency)
+- **Evaluation Suite** (`tests/eval/`) — 52 tests across 4 files:
+  - *Retrieval quality* — recall@1, recall@3, MRR (0.70 threshold), distractor suppression across 11 gold queries on 7-paper seed corpus (GPU, real BGE embeddings)
+  - *Reranker effectiveness* — surface-vs-deep promotion test, no-degradation guard on seed corpus (CPU+GPU)
+  - *Context boosting* — 5 tests verifying +0.15/+0.30/+0.075 boost mechanics, cap at 1.0 (CPU-only)
+  - *Synthesis unit* — query classification heuristics (11 cases), prompt citation structure, graceful no-source handling (CPU-only)
 
 ## February 22, 2026
 - **SQLite Metadata Index** — dual-write/delegated-read layer (`KBMetadataStore`) alongside ChromaDB; `list_papers()`, `get_stats()`, `list_notes()` now hit SQLite instead of scanning all chunks ([rationale](STORAGE_PHILOSOPHY.md))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,8 @@
 Implementation history for the Research Agent project.
 
 ## February 24, 2026
+- **Native Claude Tool Use** — when Anthropic API key is set, Claude uses native tool calling to decide which tools to use and in what order (search_local_kb, search_academic, search_web), bypassing the rigid LangGraph pipeline; falls back to LangGraph for other providers or on error; `is_claude` property, `_run_with_claude_tools()` async loop, `canonical_provider` threading through init chain
+- **25 new tests** for Claude tool-use integration (detection, tool schemas, dispatch, full loop, result format parity, fallback, BYOK)
 - **Researcher ↔ KB Paper Linking** — auto-link KB papers to known researchers on ingestion and lookup; `update_paper_metadata()` dual-write in VectorStore; `match_author_name()` in ResearcherRegistry; `researcher_linker` module for full-scan and targeted linking
 - **Researchers Browser** — new accordion in KB tab: table with Name/Affiliation/Registry Papers/KB Papers/Citations/h-index, Re-link button, delete by name
 - **Duplicate wiring fix** — merged two `papers_table.select` bindings into one (was firing `select_kb_paper_with_context` twice per click)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,12 @@ Active priorities and future ideas for the Research Agent.
 - [ ] **Fine-tuning** — domain-specific model training
 - [ ] **Collaborative Features** — share knowledge bases
 
+## Claude & LLM Intelligence
+
+- [x] **Native Claude Tool Use** — when Anthropic key is set, Claude uses native tool calling (search_local_kb, search_academic, search_web) instead of rigid LangGraph pipeline; auto-fallback to LangGraph for other providers
+- [ ] **MCP Server** — expose KB search, researcher lookup, paper search as MCP tools for Claude Code CLI
+- [ ] **Reranker Fine-Tuning** — domain-specific CrossEncoder training on eval corpus (critical social theory, Sámi epistemology, Arctic geography)
+
 ## Ideas / Future
 
 - [ ] Integration with Zotero

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,8 +7,9 @@ Active priorities and future ideas for the Research Agent.
 - [x] **Auto-Save Web Results from Researcher Lookup** — save DuckDuckGo results to `web_sources`, "Save to KB" button next to each result
 - [x] **Auto-Save Citation Abstracts** — persist cited/citing paper abstracts to KB via S2 batch API, auto-save toggle in Citation Explorer
 - [x] **Additional Cloud LLM Providers** — Gemini, Mistral, xAI/Grok via OpenAI-compatible APIs
-- [ ] **Multi-Model Pipeline** — fast/cheap model for query classification, capable model for synthesis, configurable per task type
-- [ ] **Perplexity Integration** — web-grounded answers with citations, replace/augment DuckDuckGo
+- [x] **Multi-Model Pipeline** — fast/cheap model for query classification, capable model for synthesis, configurable per task type via UI
+- [x] **Perplexity Integration** — web-grounded answers with citations, switchable web search provider (DuckDuckGo/Perplexity/Tavily/Serper)
+- [x] **CORE API Integration** — 300M+ open access papers, integrated into external search pipeline
 
 ## Medium Priority
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@ Active priorities and future ideas for the Research Agent.
 
 - [x] **Notes Browser in KB Tab** — list, refresh, delete by ID
 - [x] **Web Sources Browser in KB Tab** — list with URL/title/date, delete
-- [ ] **Researcher Profile Persistence** — persist ResearcherRegistry to SQLite, link researchers to KB papers
+- [x] **Researcher Profile Persistence** — persist ResearcherRegistry to SQLite, link researchers to KB papers, Researchers Browser UI
 
 ## Low Priority
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@ Active priorities and future ideas for the Research Agent.
 
 ## Low Priority
 
-- [ ] **Evaluation Suite** — test retrieval and synthesis quality, benchmark embedding + reranker
+- [x] **Evaluation Suite** — retrieval quality (recall@1, MRR, distractor suppression), reranker effectiveness, context boosting, synthesis correctness
 - [ ] **Fine-tuning** — domain-specific model training
 - [ ] **Collaborative Features** — share knowledge bases
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,5 @@ markers =
     network: requires network access
     asyncio: async test (pytest-asyncio)
     timeout(duration): fail if test exceeds duration
+    gpu: requires CUDA GPU (real embedder or reranker loaded)
+    eval: retrieval and synthesis quality evaluation tests

--- a/src/research_agent/agents/research_agent.py
+++ b/src/research_agent/agents/research_agent.py
@@ -81,6 +81,7 @@ class ResearchAgent:
         config: Optional[AgentConfig] = None,
         use_ollama: bool = False,
         provider: Optional[str] = None,
+        canonical_provider: Optional[str] = None,
         ollama_model: str = "mistral",
         ollama_base_url: str = "http://localhost:11434",
         openai_model: str = "gpt-4o-mini",
@@ -104,6 +105,7 @@ class ResearchAgent:
         self._load_model_on_demand = True
         self.use_ollama = use_ollama
         self.provider = provider or ("ollama" if use_ollama else "huggingface")
+        self._canonical_provider = canonical_provider or self.provider
         self._openai_fallback_models = openai_models or []
         self._openai_compat_fallback_models = openai_compat_models or []
         self._ollama_base_url = ollama_base_url
@@ -219,6 +221,11 @@ class ResearchAgent:
         elif self.tokenizer:
             return self.tokenizer.name_or_path
         return "unknown"
+
+    @property
+    def is_claude(self) -> bool:
+        """True when the underlying provider is Anthropic (native tool-use eligible)."""
+        return self._canonical_provider == "anthropic" and bool(self._openai_api_key)
 
     def list_available_models(self) -> list:
         """List available models for the active provider."""
@@ -341,6 +348,7 @@ class ResearchAgent:
                 fallback_models=cloud_cfg["models"],
             )
             self.tokenizer = None
+            self._canonical_provider = provider_key
             self.provider = "openai"
             self.use_ollama = False
             self._load_model_on_demand = False
@@ -1374,6 +1382,589 @@ Response:"""
 
         return {**state, "final_answer": final_answer}
 
+    # ── Native Claude tool-use path ─────────────────────────────────────
+
+    def _get_claude_tool_definitions(self) -> List[Dict]:
+        """Return Anthropic tool schemas for the research agent's capabilities."""
+        return [
+            {
+                "name": "search_local_kb",
+                "description": (
+                    "Search the user's personal knowledge base (papers, notes, "
+                    "and web sources stored in the vector database). Use this "
+                    "first to check what the user already has before searching "
+                    "externally."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query to find relevant papers, notes, or web sources",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "search_academic",
+                "description": (
+                    "Search academic databases (OpenAlex, Semantic Scholar, CORE) "
+                    "for published research papers. Returns papers with titles, "
+                    "authors, years, citation counts, and abstracts."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Academic search query (keywords, author names, topics)",
+                        },
+                        "year_from": {
+                            "type": "integer",
+                            "description": "Only return papers published after this year",
+                        },
+                        "year_to": {
+                            "type": "integer",
+                            "description": "Only return papers published before this year",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "search_web",
+                "description": (
+                    "Search the web for grey literature, reports, news articles, "
+                    "and non-academic sources. Use for current events, policy "
+                    "documents, or organizational reports."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Web search query",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+        ]
+
+    def _build_claude_system_prompt(self, context: Dict) -> str:
+        """Build system prompt for Claude's native tool-use mode."""
+        parts = [
+            "You are a research assistant with access to a personal knowledge base "
+            "of academic papers, notes, and web sources.",
+            "",
+            "Your workflow:",
+            "1. ALWAYS search the local knowledge base first to check what the user already has.",
+            "2. If local results are insufficient (fewer than 3 relevant results), search academic databases.",
+            "3. For current events, policy documents, or grey literature, also search the web.",
+            "4. Synthesize all findings into a clear, well-organized answer.",
+            "",
+            "Citation format:",
+            "- Number all sources sequentially as [1], [2], [3], etc.",
+            "- Cite sources inline in your answer using these numbers.",
+            "- Base your answer on the CONTENT of sources, not just their titles.",
+            "- If sources conflict, note the disagreement.",
+            "",
+            "Response style:",
+            "- Use markdown formatting for readability.",
+            "- For literature reviews: provide thematic overview, key findings, and research gaps.",
+            "- For factual questions: give precise answers with specific citations.",
+            "- For analysis requests: compare perspectives and evaluate evidence.",
+            "- For casual greetings or simple questions: respond naturally without using tools.",
+        ]
+
+        # Add context from UI selection
+        current_researcher = context.get("researcher")
+        current_paper_id = context.get("paper_id")
+        auth_items = context.get("auth_items", [])
+        chat_items = context.get("chat_items", [])
+
+        if current_researcher:
+            parts.append(
+                f"\nThe user is currently focused on researcher: {current_researcher}. "
+                "Prioritize information about their work."
+            )
+        if current_paper_id:
+            parts.append(
+                f"\nThe user has a specific paper selected (ID: {current_paper_id[:30]}). "
+                "Consider this context when searching."
+            )
+        if auth_items:
+            parts.append(f"\nPinned research topics: {', '.join(auth_items)}")
+        if chat_items:
+            parts.append(f"\nRecent conversation topics: {', '.join(chat_items)}")
+
+        return "\n".join(parts)
+
+    def _format_tool_results(self, results: List[Dict], source_type: str) -> str:
+        """Format search results as text for Claude to reference in its answer."""
+        if not results:
+            return f"No {source_type} results found."
+
+        lines = [f"Found {len(results)} {source_type} result(s):\n"]
+        for i, r in enumerate(results, 1):
+            title = r.get("title", "Unknown")
+            authors = r.get("authors", "")
+            year = r.get("year", "")
+            content = str(r.get("content", ""))[:600]
+            citations = r.get("citation_count")
+            url = r.get("url", "")
+
+            lines.append(f"[{i}] {title}")
+            if authors and authors != "User Note":
+                lines.append(f"    Authors: {authors}")
+            if year:
+                lines.append(f"    Year: {year}")
+            if citations:
+                lines.append(f"    Citations: {citations}")
+            if url:
+                lines.append(f"    URL: {url}")
+            if content:
+                lines.append(f"    Excerpt: {content}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+    async def _execute_claude_tool(
+        self,
+        tool_name: str,
+        tool_input: Dict,
+        all_local: List[Dict],
+        all_external: List[Dict],
+        context: Dict,
+    ) -> str:
+        """Execute a Claude tool call against existing search infrastructure."""
+
+        if tool_name == "search_local_kb":
+            return await self._claude_search_local(
+                tool_input["query"], all_local, context,
+            )
+
+        elif tool_name == "search_academic":
+            return await self._claude_search_academic(
+                tool_input["query"],
+                year_from=tool_input.get("year_from"),
+                year_to=tool_input.get("year_to"),
+                results_out=all_external,
+            )
+
+        elif tool_name == "search_web":
+            return await self._claude_search_web(
+                tool_input["query"], all_external,
+            )
+
+        return f"Unknown tool: {tool_name}"
+
+    async def _claude_search_local(
+        self,
+        query: str,
+        results_out: List[Dict],
+        context: Dict,
+    ) -> str:
+        """Local KB search for Claude tool-use path."""
+        if not self.vector_store or not self.embedder:
+            return "Knowledge base is not configured."
+
+        try:
+            # Generate query embedding (same logic as _search_local)
+            if hasattr(self.embedder, "embed_query"):
+                query_embedding = self.embedder.embed_query(query)
+            elif hasattr(self.embedder, "embed"):
+                query_embedding = self.embedder.embed(query)
+            elif hasattr(self.embedder, "encode"):
+                query_embedding = self.embedder.encode(query)
+            else:
+                return "Error: Embedder does not support query embedding."
+
+            if hasattr(query_embedding, "tolist"):
+                query_embedding = query_embedding.tolist()
+
+            # Year filters from config
+            filter_dict = None
+            if self.config.year_range:
+                year_from, year_to = self.config.year_range
+                filter_dict = {
+                    "$and": [
+                        {"year": {"$gte": year_from}},
+                        {"year": {"$lte": year_to}},
+                    ]
+                }
+
+            _empty = {"documents": [], "metadatas": [], "distances": []}
+            loop = asyncio.get_running_loop()
+
+            def _search_papers():
+                return self.vector_store.search(
+                    query_embedding=query_embedding,
+                    collection="papers",
+                    n_results=self.config.max_local_results * 2,
+                    filter_dict=filter_dict,
+                    query_text=query,
+                )
+
+            def _search_notes():
+                try:
+                    return self.vector_store.search(
+                        query_embedding=query_embedding,
+                        collection="notes",
+                        n_results=max(3, self.config.max_local_results // 2),
+                        query_text=query,
+                    )
+                except Exception:
+                    return _empty
+
+            def _search_web_sources():
+                try:
+                    return self.vector_store.search(
+                        query_embedding=query_embedding,
+                        collection="web_sources",
+                        n_results=max(3, self.config.max_local_results // 2),
+                        query_text=query,
+                    )
+                except Exception:
+                    return _empty
+
+            paper_results, notes_results, web_results = await asyncio.gather(
+                loop.run_in_executor(None, _search_papers),
+                loop.run_in_executor(None, _search_notes),
+                loop.run_in_executor(None, _search_web_sources),
+            )
+
+            local_results = []
+
+            # Format paper results
+            for i, doc in enumerate(paper_results.get("documents", [])):
+                meta = paper_results.get("metadatas", [{}])[i] if paper_results.get("metadatas") else {}
+                dist = paper_results.get("distances", [1.0])[i] if paper_results.get("distances") else 1.0
+                raw_authors = meta.get("authors", "")
+                authors_str = ", ".join(raw_authors) if isinstance(raw_authors, list) else (raw_authors or "")
+                local_results.append({
+                    "content": doc,
+                    "title": meta.get("title", "Unknown"),
+                    "authors": authors_str,
+                    "year": meta.get("year"),
+                    "paper_id": meta.get("paper_id", ""),
+                    "source": "local_kb",
+                    "relevance_score": 1 - dist,
+                })
+
+            # Format notes results
+            for i, doc in enumerate(notes_results.get("documents", [])):
+                meta = notes_results.get("metadatas", [{}])[i] if notes_results.get("metadatas") else {}
+                dist = notes_results.get("distances", [1.0])[i] if notes_results.get("distances") else 1.0
+                local_results.append({
+                    "content": doc,
+                    "title": meta.get("title", "Research Note"),
+                    "authors": "User Note",
+                    "year": None,
+                    "paper_id": meta.get("note_id", ""),
+                    "source": "local_note",
+                    "tags": meta.get("tags", ""),
+                    "relevance_score": 1 - dist,
+                })
+
+            # Format web source results
+            for i, doc in enumerate(web_results.get("documents", [])):
+                meta = web_results.get("metadatas", [{}])[i] if web_results.get("metadatas") else {}
+                dist = web_results.get("distances", [1.0])[i] if web_results.get("distances") else 1.0
+                local_results.append({
+                    "content": doc,
+                    "title": meta.get("title", "Web Source"),
+                    "authors": "",
+                    "year": None,
+                    "paper_id": meta.get("source_id", ""),
+                    "url": meta.get("url", ""),
+                    "source": "local_web",
+                    "relevance_score": 1 - dist,
+                })
+
+            # Apply context boosting (same as _search_local:860-898)
+            current_researcher = context.get("researcher")
+            current_paper_id = context.get("paper_id")
+            if current_researcher or current_paper_id:
+                boost_amount = 0.15
+
+                def _str_authors(val):
+                    if isinstance(val, list):
+                        return ", ".join(str(a) for a in val)
+                    return str(val) if val else ""
+
+                context_paper = None
+                if current_paper_id:
+                    context_paper = self.vector_store.get_paper(current_paper_id)
+
+                for result in local_results:
+                    if current_researcher:
+                        authors = _str_authors(result.get("authors", "")).lower()
+                        if current_researcher.lower() in authors:
+                            result["relevance_score"] = min(1.0, result["relevance_score"] + boost_amount)
+
+                    if current_paper_id and context_paper:
+                        pid = result.get("paper_id", "")
+                        if pid == current_paper_id:
+                            result["relevance_score"] = min(1.0, result["relevance_score"] + boost_amount * 2)
+                        elif context_paper.get("metadata", {}).get("authors"):
+                            ctx_authors = _str_authors(context_paper["metadata"]["authors"]).lower()
+                            res_authors = _str_authors(result.get("authors", "")).lower()
+                            if any(a.strip() in res_authors for a in ctx_authors.split(",") if len(a.strip()) > 3):
+                                result["relevance_score"] = min(1.0, result["relevance_score"] + boost_amount * 0.5)
+
+            local_results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
+            local_results = local_results[:self.config.max_local_results]
+
+            results_out.extend(local_results)
+            return self._format_tool_results(local_results, "local knowledge base")
+
+        except Exception as e:
+            logger.error(f"Claude local search error: {e}")
+            return f"Error searching knowledge base: {e}"
+
+    async def _claude_search_academic(
+        self,
+        query: str,
+        year_from: Optional[int] = None,
+        year_to: Optional[int] = None,
+        results_out: Optional[List[Dict]] = None,
+    ) -> str:
+        """Academic search for Claude tool-use path."""
+        if not self.academic_search:
+            return "Academic search is not configured."
+
+        # Use config year range as fallback
+        if year_from is None and self.config.year_range:
+            year_from = self.config.year_range[0]
+        if year_to is None and self.config.year_range:
+            year_to = self.config.year_range[1]
+        year_range = (year_from, year_to) if year_from and year_to else None
+        min_citations = max(0, int(self.config.min_citations or 0))
+
+        max_ext = self.config.max_external_results
+        openalex_limit = max(1, (max_ext * 2) // 3)
+        s2_limit = max_ext - openalex_limit
+
+        try:
+            async def _fetch_openalex():
+                try:
+                    return await self.academic_search.search_openalex(
+                        query, limit=openalex_limit,
+                        from_year=year_from, to_year=year_to,
+                    )
+                except Exception as e:
+                    logger.error(f"OpenAlex search error: {e}")
+                    return []
+
+            async def _fetch_s2():
+                try:
+                    return await self.academic_search.search_semantic_scholar(
+                        query, limit=s2_limit, year_range=year_range,
+                    )
+                except Exception as e:
+                    logger.error(f"Semantic Scholar search error: {e}")
+                    return []
+
+            async def _fetch_core():
+                if not self.config.include_core_search:
+                    return []
+                try:
+                    return await self.academic_search.search_core(
+                        query, limit=max(1, max_ext // 3),
+                        from_year=year_from, to_year=year_to,
+                    )
+                except Exception as e:
+                    logger.error(f"CORE search error: {e}")
+                    return []
+
+            oa_papers, s2_papers, core_papers = await asyncio.gather(
+                _fetch_openalex(), _fetch_s2(), _fetch_core(),
+            )
+
+            # Dedup by DOI / title (same logic as _search_external)
+            seen_dois: set = set()
+            seen_titles: set = set()
+            external_results: List[Dict] = []
+
+            def _title_key(title: str) -> str:
+                return (title or "").strip().lower()[:80]
+
+            for papers, source_label in [
+                (oa_papers, "openalex"),
+                (s2_papers, "semantic_scholar"),
+                (core_papers, "core"),
+            ]:
+                for paper in papers:
+                    cites = paper.citation_count or 0
+                    if min_citations and cites < min_citations:
+                        continue
+                    if paper.doi and paper.doi in seen_dois:
+                        continue
+                    tk = _title_key(paper.title)
+                    if tk and tk in seen_titles:
+                        continue
+                    if paper.doi:
+                        seen_dois.add(paper.doi)
+                    if tk:
+                        seen_titles.add(tk)
+                    external_results.append({
+                        "content": paper.abstract or "",
+                        "title": paper.title,
+                        "authors": ", ".join(paper.authors) if paper.authors else "",
+                        "year": paper.year,
+                        "paper_id": paper.paper_id,
+                        "doi": paper.doi,
+                        "citation_count": cites,
+                        "url": paper.url,
+                        "source": source_label,
+                    })
+
+            if results_out is not None:
+                results_out.extend(external_results)
+            return self._format_tool_results(external_results, "academic")
+
+        except Exception as e:
+            logger.error(f"Claude academic search error: {e}")
+            return f"Error searching academic databases: {e}"
+
+    async def _claude_search_web(
+        self,
+        query: str,
+        results_out: List[Dict],
+    ) -> str:
+        """Web search for Claude tool-use path."""
+        if not self.web_search:
+            return "Web search is not configured."
+
+        try:
+            web_results = await self.web_search.search(query, max_results=5)
+            formatted = []
+            for result in web_results:
+                title = result.get("title") if isinstance(result, dict) else getattr(result, "title", "")
+                url = result.get("url") if isinstance(result, dict) else getattr(result, "url", "")
+                content = result.get("snippet") if isinstance(result, dict) else getattr(result, "content", "")
+                entry = {
+                    "content": content or "",
+                    "title": title or "",
+                    "url": url or "",
+                    "source": "web",
+                }
+                formatted.append(entry)
+
+            results_out.extend(formatted)
+            return self._format_tool_results(formatted, "web")
+
+        except Exception as e:
+            logger.error(f"Claude web search error: {e}")
+            return f"Error searching the web: {e}"
+
+    async def _run_with_claude_tools(
+        self,
+        user_query: str,
+        search_filters: Optional[Dict[str, Any]] = None,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Run the agent using Claude's native tool calling.
+
+        Claude decides which tools to call and in what order. Falls back
+        to the LangGraph pipeline if the anthropic SDK is not installed
+        or the API call fails.
+        """
+        import anthropic
+
+        context = context or {}
+
+        # Apply search filters to config (same as _run_async)
+        if search_filters:
+            if "year_from" in search_filters or "year_to" in search_filters:
+                year_from = search_filters.get("year_from", 1900)
+                year_to = search_filters.get("year_to", 2030)
+                self.config.year_range = (year_from, year_to)
+            if search_filters.get("min_citations") is not None:
+                try:
+                    self.config.min_citations = int(search_filters["min_citations"])
+                except (TypeError, ValueError):
+                    self.config.min_citations = 0
+
+        client = anthropic.AsyncAnthropic(api_key=self._openai_api_key)
+        model = self.model.model_name if self.model else "claude-sonnet-4-6"
+        system_prompt = self._build_claude_system_prompt(context)
+        tools = self._get_claude_tool_definitions()
+        messages: List[Dict] = [{"role": "user", "content": user_query}]
+        all_local: List[Dict] = []
+        all_external: List[Dict] = []
+
+        MAX_TURNS = 6
+        final_text = ""
+
+        for _ in range(MAX_TURNS):
+            response = await client.messages.create(
+                model=model,
+                max_tokens=2048,
+                system=system_prompt,
+                tools=tools,
+                messages=messages,
+            )
+
+            # If Claude is done, extract the final text
+            if response.stop_reason == "end_turn":
+                final_text = "".join(
+                    b.text for b in response.content if b.type == "text"
+                )
+                break
+
+            # Append assistant turn (with tool_use blocks)
+            messages.append({"role": "assistant", "content": response.content})
+
+            # Execute each tool call and build tool_result blocks
+            tool_results = []
+            for block in response.content:
+                if block.type == "tool_use":
+                    result_text = await self._execute_claude_tool(
+                        block.name, block.input,
+                        all_local, all_external, context,
+                    )
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result_text,
+                    })
+
+            if tool_results:
+                messages.append({"role": "user", "content": tool_results})
+        else:
+            final_text = (
+                "I wasn't able to complete the research in the allowed number of steps. "
+                "Please try a more specific query."
+            )
+
+        logger.info(
+            "Claude tool-use complete: %d local, %d external sources",
+            len(all_local), len(all_external),
+        )
+
+        # Return same dict format as _run_async
+        all_sources = all_local + all_external
+        return {
+            "query": user_query,
+            "answer": final_text,
+            "query_type": "general" if not all_sources else "literature_review",
+            "local_sources": len(all_local),
+            "external_sources": len(all_external),
+            "sources": [
+                {
+                    "title": s.get("title"),
+                    "authors": s.get("authors", ""),
+                    "source": s.get("source"),
+                    "year": s.get("year"),
+                    "url": s.get("url", ""),
+                }
+                for s in all_sources[:10]
+            ],
+        }
+
     async def _run_async(
         self,
         user_query: str,
@@ -1441,6 +2032,21 @@ Response:"""
 
         if search_filters:
             result["search_filters"] = search_filters
+
+        # Native Claude tool-use path (bypasses LangGraph)
+        if self.is_claude:
+            try:
+                return await self._run_with_claude_tools(
+                    user_query, search_filters, context,
+                )
+            except ImportError:
+                logger.warning(
+                    "anthropic SDK not installed, using LangGraph pipeline"
+                )
+            except Exception as e:
+                logger.error(
+                    "Claude tool-use failed (%s), falling back to LangGraph", e,
+                )
 
         try:
             # Run the graph
@@ -1525,6 +2131,7 @@ def create_research_agent(
     config: Optional[AgentConfig] = None,
     use_ollama: bool = False,
     provider: Optional[str] = None,
+    canonical_provider: Optional[str] = None,
     ollama_model: str = "mistral",
     ollama_base_url: str = "http://localhost:11434",
     openai_model: str = "gpt-4o-mini",
@@ -1551,6 +2158,7 @@ def create_research_agent(
         config=config,
         use_ollama=use_ollama,
         provider=provider,
+        canonical_provider=canonical_provider,
         ollama_model=ollama_model,
         ollama_base_url=ollama_base_url,
         openai_model=openai_model,

--- a/src/research_agent/db/researcher_linker.py
+++ b/src/research_agent/db/researcher_linker.py
@@ -1,0 +1,92 @@
+"""Auto-link KB papers to known researchers in the registry."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Tuple
+
+if TYPE_CHECKING:
+    from research_agent.db.vector_store import ResearchVectorStore
+    from research_agent.tools.researcher_registry import ResearcherRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def link_papers_to_researchers(
+    vector_store: ResearchVectorStore,
+    registry: ResearcherRegistry,
+) -> Tuple[int, int]:
+    """Scan all unlinked KB papers and link them to known researchers.
+
+    Args:
+        vector_store: Vector store (with SQLite metadata index)
+        registry: Researcher registry with known profiles
+
+    Returns:
+        (linked_count, scanned_count)
+    """
+    meta = vector_store._meta
+    if meta is None:
+        return 0, 0
+
+    unlinked = meta.list_unlinked_papers()
+    linked = 0
+
+    for paper in unlinked:
+        authors_str = paper.get("authors", "")
+        if not authors_str:
+            continue
+        authors = [a.strip() for a in authors_str.split(",")]
+        for author in authors:
+            match = registry.match_author_name(author)
+            if match:
+                vector_store.update_paper_metadata(
+                    paper["paper_id"], {"researcher": match}
+                )
+                linked += 1
+                break
+
+    if linked:
+        logger.info(f"Auto-linked {linked}/{len(unlinked)} papers to researchers")
+    return linked, len(unlinked)
+
+
+def link_papers_for_researcher(
+    vector_store: ResearchVectorStore,
+    researcher_name: str,
+) -> int:
+    """Link unlinked KB papers that match a specific researcher name.
+
+    Args:
+        vector_store: Vector store (with SQLite metadata index)
+        researcher_name: Display name to match against paper authors
+
+    Returns:
+        Number of papers linked
+    """
+    meta = vector_store._meta
+    if meta is None:
+        return 0
+
+    unlinked = meta.list_unlinked_papers()
+    linked = 0
+    name_lower = researcher_name.lower().strip()
+
+    for paper in unlinked:
+        authors_str = paper.get("authors", "")
+        if not authors_str:
+            continue
+        authors = [a.strip() for a in authors_str.split(",")]
+        for author in authors:
+            if author.lower().strip() == name_lower:
+                vector_store.update_paper_metadata(
+                    paper["paper_id"], {"researcher": researcher_name}
+                )
+                linked += 1
+                break
+
+    if linked:
+        logger.info(
+            f"Auto-linked {linked} papers to researcher '{researcher_name}'"
+        )
+    return linked

--- a/src/research_agent/main.py
+++ b/src/research_agent/main.py
@@ -71,6 +71,13 @@ CLOUD_PROVIDERS = {
         "default_model": "grok-3-mini-fast",
         "models": ["grok-3-mini-fast", "grok-3-mini", "grok-3-fast", "grok-3"],
     },
+    "perplexity": {
+        "name": "Perplexity AI",
+        "base_url": "https://api.perplexity.ai",
+        "api_key_env": "PERPLEXITY_API_KEY",
+        "default_model": "sonar",
+        "models": ["sonar", "sonar-pro", "sonar-reasoning"],
+    },
 }
 
 
@@ -92,10 +99,11 @@ def detect_available_provider(config: dict) -> Tuple[str, Optional[dict]]:
     1. OpenAI (if OPENAI_API_KEY is set)
     2. Anthropic (if ANTHROPIC_API_KEY is set)
     3. Groq (if GROQ_API_KEY is set - free tier!)
-    4. OpenRouter (if OPENROUTER_API_KEY is set)
-    5. Ollama (if server is reachable)
-    6. HuggingFace (local, requires GPU)
-    7. None (retrieval-only mode)
+    4. Perplexity (if PERPLEXITY_API_KEY is set)
+    5. OpenRouter (if OPENROUTER_API_KEY is set)
+    6. Ollama (if server is reachable)
+    7. HuggingFace (local, requires GPU)
+    8. None (retrieval-only mode)
 
     Returns:
         Tuple of (provider_name, provider_config) or (provider_name, None) for local providers
@@ -103,7 +111,7 @@ def detect_available_provider(config: dict) -> Tuple[str, Optional[dict]]:
     model_cfg = config.get("model", {}) if isinstance(config, dict) else {}
 
     # Check cloud providers in priority order
-    for provider_key in ["openai", "anthropic", "groq", "gemini", "mistral", "xai", "openrouter"]:
+    for provider_key in ["openai", "anthropic", "groq", "perplexity", "gemini", "mistral", "xai", "openrouter"]:
         provider = CLOUD_PROVIDERS[provider_key]
         api_key = os.getenv(provider["api_key_env"])
         if api_key:
@@ -399,6 +407,8 @@ def build_agent_from_config(config: dict):
         web_api_key = os.getenv("TAVILY_API_KEY")
     elif web_provider == "serper":
         web_api_key = os.getenv("SERPER_API_KEY")
+    elif web_provider == "perplexity":
+        web_api_key = os.getenv("PERPLEXITY_API_KEY")
 
     web_search = WebSearchTool(api_key=web_api_key, provider=web_provider)
 

--- a/src/research_agent/main.py
+++ b/src/research_agent/main.py
@@ -513,6 +513,7 @@ def build_agent_from_config(config: dict):
         config=agent_config,
         use_ollama=use_ollama,
         provider=provider,
+        canonical_provider=canonical_provider,
         ollama_model=ollama_model,
         ollama_base_url=ollama_base_url,
         openai_model=openai_default_model,

--- a/src/research_agent/tools/researcher_lookup.py
+++ b/src/research_agent/tools/researcher_lookup.py
@@ -34,7 +34,13 @@ class AuthorPaper(BasePaper):
     """A paper authored by a researcher.
 
     Inherits all fields from BasePaper. Source defaults to "unknown".
+    Enrichment fields are populated after initial lookup by
+    ``enrich_papers_oa_status()`` and the S2 batch embedding endpoint.
     """
+
+    oa_status: Optional[str] = None
+    open_access_url: Optional[str] = None
+    tldr: Optional[str] = None
 
     def __post_init__(self):
         if self.source is None:

--- a/src/research_agent/tools/researcher_registry.py
+++ b/src/research_agent/tools/researcher_registry.py
@@ -131,6 +131,29 @@ class ResearcherRegistry:
                     return profile
             return None
 
+    def match_author_name(self, author: str) -> Optional[str]:
+        """Match an author string to a known researcher.
+
+        Args:
+            author: Author name (e.g. from paper metadata)
+
+        Returns:
+            Display name of the matched researcher, or None
+        """
+        with self._registry_lock:
+            key = author.lower().strip()
+            if not key:
+                return None
+            # Direct key lookup
+            profile = self._researchers.get(key)
+            if profile:
+                return profile.name
+            # Fallback: match against display names
+            for p in self._researchers.values():
+                if p.name.lower().strip() == key:
+                    return p.name
+            return None
+
     def list_all(self) -> List[ResearcherProfile]:
         """
         Get all researcher profiles in the registry.

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -67,6 +67,21 @@ class WebSearchTool:
             await self._client.aclose()
             self._client = None
 
+    def set_provider(self, provider: str, api_key: str | None = None) -> None:
+        """Switch web search provider at runtime.
+
+        Args:
+            provider: One of "duckduckgo", "tavily", "serper", "perplexity".
+            api_key: API key for the new provider (required for tavily/serper/perplexity).
+        """
+        valid = {"duckduckgo", "tavily", "serper", "perplexity"}
+        if provider not in valid:
+            raise ValueError(f"Unknown provider: {provider}. Valid: {valid}")
+        self.provider = provider
+        if api_key is not None:
+            self.api_key = api_key
+        logger.info("Web search provider switched to: %s", provider)
+
     @timed
     async def search(
         self,

--- a/src/research_agent/tools/web_search.py
+++ b/src/research_agent/tools/web_search.py
@@ -6,6 +6,7 @@ Supports multiple providers:
 - DuckDuckGo (free, no API key required)
 - Tavily (optimized for AI, requires API key)
 - Serper (Google search results, requires API key)
+- Perplexity (web-grounded answers with citations, requires API key)
 """
 
 import asyncio
@@ -83,6 +84,8 @@ class WebSearchTool:
             return await self._search_tavily(query, max_results)
         elif self.provider == "serper":
             return await self._search_serper(query, max_results)
+        elif self.provider == "perplexity":
+            return await self._search_perplexity(query, max_results)
         else:
             raise ValueError(f"Unknown provider: {self.provider}")
 
@@ -249,3 +252,125 @@ class WebSearchTool:
         except httpx.HTTPError as e:
             logger.error(f"Serper API error: {e}")
             return []
+
+    async def _search_perplexity(
+        self,
+        query: str,
+        max_results: int
+    ) -> List[WebResult]:
+        """
+        Search using Perplexity's sonar model for web-grounded answers.
+
+        Returns a synthesized answer with cited sources.
+        Each citation URL becomes a WebResult.
+        Requires PERPLEXITY_API_KEY.
+        """
+        if not self.api_key:
+            raise ValueError(
+                "Perplexity API key required. Set PERPLEXITY_API_KEY in your environment."
+            )
+
+        client = await self._get_client()
+
+        try:
+            response = await retry_with_backoff(
+                lambda: client.post(
+                    "https://api.perplexity.ai/chat/completions",
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": "sonar",
+                        "messages": [
+                            {"role": "user", "content": f"Search: {query}"}
+                        ],
+                    },
+                ),
+                max_retries=2, base_delay=1.0, retry_on=(429, 503, 504),
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            # Extract the synthesized answer
+            content = ""
+            if data.get("choices"):
+                content = data["choices"][0].get("message", {}).get("content", "")
+
+            # Extract citations (list of URLs at the top level of the response)
+            citations = data.get("citations", [])
+
+            results = []
+            if citations:
+                # Build one WebResult per citation, linking snippet context
+                for i, url in enumerate(citations[:max_results]):
+                    # Try to extract the snippet around the citation reference [i+1]
+                    marker = f"[{i + 1}]"
+                    snippet = _extract_citation_snippet(content, marker)
+                    title = _title_from_url(url)
+
+                    results.append(WebResult(
+                        title=title,
+                        url=url,
+                        content=snippet or content,
+                        raw_content=content if i == 0 else None,
+                        score=None,
+                    ))
+            elif content:
+                # No citations returned — wrap the whole answer as a single result
+                results.append(WebResult(
+                    title=f"Perplexity answer: {query[:80]}",
+                    url="",
+                    content=content,
+                    raw_content=content,
+                    score=None,
+                ))
+
+            logger.info(
+                f"Perplexity found {len(results)} results for: {query}"
+            )
+            return results
+
+        except httpx.HTTPError as e:
+            logger.error(f"Perplexity API error: {e}")
+            return []
+
+
+def _extract_citation_snippet(content: str, marker: str, context_chars: int = 200) -> str:
+    """Extract text surrounding a citation marker like [1] from the response."""
+    import re
+    # Escape the marker for regex (brackets are special)
+    escaped = re.escape(marker)
+    # Find the sentence(s) containing this marker
+    # Look for text around the marker
+    match = re.search(escaped, content)
+    if not match:
+        return ""
+    start = max(0, match.start() - context_chars)
+    end = min(len(content), match.end() + context_chars)
+    snippet = content[start:end].strip()
+    # Clean up partial words at boundaries
+    if start > 0:
+        snippet = "..." + snippet.split(" ", 1)[-1] if " " in snippet else "..." + snippet
+    if end < len(content):
+        snippet = snippet.rsplit(" ", 1)[0] + "..." if " " in snippet else snippet + "..."
+    return snippet
+
+
+def _title_from_url(url: str) -> str:
+    """Derive a readable title from a URL."""
+    from urllib.parse import urlparse
+    try:
+        parsed = urlparse(url)
+        domain = parsed.netloc.replace("www.", "")
+        # Use the last meaningful path segment as a hint
+        path_parts = [p for p in parsed.path.strip("/").split("/") if p]
+        if path_parts:
+            slug = path_parts[-1].replace("-", " ").replace("_", " ")
+            # Truncate very long slugs
+            if len(slug) > 60:
+                slug = slug[:57] + "..."
+            return f"{slug} ({domain})"
+        return domain
+    except Exception:
+        return url[:80]

--- a/src/research_agent/ui/app.py
+++ b/src/research_agent/ui/app.py
@@ -2714,7 +2714,7 @@ def create_app(agent=None):
             stats, table = refresh_stats_and_table(
                 year_from, year_to, min_citations, new_state
             )
-            return new_state, paper_id, stats, table
+            return new_state, paper_id, paper_id, stats, table
 
         async def open_kb_citations(paper_id, direction, depth):
             """Open a KB paper in the citation explorer."""
@@ -3995,19 +3995,7 @@ def create_app(agent=None):
                 year_to_kb,
                 min_citations_kb,
             ],
-            outputs=[context_state, kb_selected_paper_id, kb_stats, papers_table],
-        )
-
-        papers_table.select(
-            select_kb_paper_with_context,
-            inputs=[
-                papers_table,
-                context_state,
-                year_from_kb,
-                year_to_kb,
-                min_citations_kb,
-            ],
-            outputs=[context_state, current_paper_id, kb_stats, papers_table],
+            outputs=[context_state, kb_selected_paper_id, current_paper_id, kb_stats, papers_table],
         )
 
         open_kb_citations_btn.click(

--- a/tests/eval/conftest.py
+++ b/tests/eval/conftest.py
@@ -1,0 +1,75 @@
+"""Eval-specific fixtures: GPU gating and session-scoped populated store."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def require_gpu():
+    """Skip the test session if no CUDA GPU is available."""
+    try:
+        import torch
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA GPU not available")
+    except ImportError:
+        pytest.skip("torch not installed")
+
+
+@pytest.fixture(scope="session")
+def populated_store(require_gpu, tmp_path_factory):
+    """Session-scoped: embed the 7 seed papers into a temp ChromaDB.
+
+    Returns (store, embedder) tuple.  Shared across all GPU eval tests.
+    """
+    from research_agent.db.vector_store import ResearchVectorStore
+    from research_agent.db.embeddings import EmbeddingModel
+    from research_agent.ui.kb_ingest import ingest_paper_to_kb
+    from tests.eval.corpus import SEED_PAPERS
+
+    tmp = tmp_path_factory.mktemp("eval_chroma")
+    embedder = EmbeddingModel(model_name="BAAI/bge-base-en-v1.5")
+    store = ResearchVectorStore(
+        persist_dir=str(tmp / "chroma"),
+        metadata_store_path=str(tmp / "meta.sqlite"),
+    )
+
+    for p in SEED_PAPERS:
+        ingest_paper_to_kb(
+            store=store,
+            embedder=embedder,
+            paper_id=p["paper_id"],
+            title=p["title"],
+            abstract=p["abstract"],
+            year=p["year"],
+            citation_count=p["citation_count"],
+            authors=p["authors"],
+            venue=p["venue"],
+            fields=p["fields"],
+            source=p["source"],
+        )
+
+    return store, embedder
+
+
+def retrieve_paper_ids(
+    store, embedder, query: str, k: int = 5
+) -> List[str]:
+    """Run the full embed -> search pipeline and return unique paper_ids."""
+    embedding = embedder.embed_query(query)
+    raw = store.search(
+        query_embedding=embedding,
+        collection="papers",
+        n_results=k * 3,
+        query_text=query,
+    )
+    seen: List[str] = []
+    for meta in raw.get("metadatas", []):
+        pid = meta.get("paper_id", "")
+        if pid and pid not in seen:
+            seen.append(pid)
+        if len(seen) >= k:
+            break
+    return seen

--- a/tests/eval/corpus.py
+++ b/tests/eval/corpus.py
@@ -1,0 +1,243 @@
+"""Gold-standard evaluation dataset for retrieval quality tests.
+
+Papers mirror scripts/seed_test_data.py. Query cases define expected
+retrieval results across three thematic clusters:
+  Harvey (urban geography / political economy) — 5 papers
+  Granovetter (social networks) — 1 paper
+  Kramvig (indigenous methodology) — 1 paper
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+# ── Paper IDs (shortcuts) ──────────────────────────────────────────────
+
+HARVEY_SOCIAL_JUSTICE = "harvey-social-justice-city-1973"
+HARVEY_POSTMODERNITY = "harvey-condition-postmodernity-1989"
+HARVEY_IMPERIALISM = "harvey-new-imperialism-2003"
+HARVEY_NEOLIBERALISM = "harvey-brief-history-neoliberalism-2005"
+HARVEY_REBEL_CITIES = "harvey-rebel-cities-2012"
+GRANOVETTER = "granovetter-weak-ties-1973"
+KRAMVIG = "kramvig-storytelling-indigenous-2014"
+
+ALL_HARVEY = [
+    HARVEY_SOCIAL_JUSTICE,
+    HARVEY_POSTMODERNITY,
+    HARVEY_IMPERIALISM,
+    HARVEY_NEOLIBERALISM,
+    HARVEY_REBEL_CITIES,
+]
+
+
+# ── Seed papers (mirrors scripts/seed_test_data.py) ───────────────────
+
+SEED_PAPERS = [
+    {
+        "paper_id": HARVEY_SOCIAL_JUSTICE,
+        "title": "Social Justice and the City",
+        "abstract": (
+            "A foundational text in radical geography examining the relationship "
+            "between social justice, urbanization, and the spatial organization "
+            "of cities through a Marxist lens."
+        ),
+        "year": 1973,
+        "citation_count": 8200,
+        "authors": ["David Harvey"],
+        "venue": "Edward Arnold",
+        "fields": ["Urban Geography", "Marxist Geography", "Social Justice"],
+        "source": "seed",
+    },
+    {
+        "paper_id": HARVEY_POSTMODERNITY,
+        "title": "The Condition of Postmodernity",
+        "abstract": (
+            "An inquiry into the origins of cultural change, exploring the "
+            "transition from modernity to postmodernity through the lens of "
+            "political economy, time-space compression, and flexible accumulation."
+        ),
+        "year": 1989,
+        "citation_count": 28000,
+        "authors": ["David Harvey"],
+        "venue": "Blackwell",
+        "fields": ["Cultural Geography", "Political Economy", "Postmodernism"],
+        "source": "seed",
+    },
+    {
+        "paper_id": HARVEY_IMPERIALISM,
+        "title": "The New Imperialism",
+        "abstract": (
+            "An analysis of the geopolitics of capitalism, introducing the "
+            "concept of accumulation by dispossession to explain how capitalist "
+            "powers maintain dominance through spatial and territorial strategies."
+        ),
+        "year": 2003,
+        "citation_count": 6500,
+        "authors": ["David Harvey"],
+        "venue": "Oxford University Press",
+        "fields": ["Political Economy", "Geopolitics", "Imperialism"],
+        "source": "seed",
+    },
+    {
+        "paper_id": HARVEY_NEOLIBERALISM,
+        "title": "A Brief History of Neoliberalism",
+        "abstract": (
+            "A critical history of neoliberalism as a political-economic practice "
+            "and theory, tracing its rise from the 1970s and its effects on "
+            "class power, inequality, and state restructuring worldwide."
+        ),
+        "year": 2005,
+        "citation_count": 18000,
+        "authors": ["David Harvey"],
+        "venue": "Oxford University Press",
+        "fields": ["Political Economy", "Neoliberalism", "Economic Geography"],
+        "source": "seed",
+    },
+    {
+        "paper_id": HARVEY_REBEL_CITIES,
+        "title": "Rebel Cities: From the Right to the City to the Urban Revolution",
+        "abstract": (
+            "An exploration of how cities have become sites of revolutionary "
+            "politics, examining urban social movements, the commons, and the "
+            "right to the city as a framework for collective action."
+        ),
+        "year": 2012,
+        "citation_count": 5000,
+        "authors": ["David Harvey"],
+        "venue": "Verso Books",
+        "fields": ["Urban Studies", "Social Movements", "Right to the City"],
+        "source": "seed",
+    },
+    {
+        "paper_id": GRANOVETTER,
+        "title": "The Strength of Weak Ties",
+        "abstract": (
+            "Analysis of the role of weak ties in social networks, demonstrating "
+            "that acquaintances (weak ties) are paradoxically more important than "
+            "close friends (strong ties) for network diffusion, job "
+            "information flow, and community organization across bridging clusters."
+        ),
+        "year": 1973,
+        "citation_count": 65000,
+        "authors": ["Mark Granovetter"],
+        "venue": "American Journal of Sociology",
+        "fields": ["Sociology", "Social Networks", "Methodology"],
+        "source": "seed",
+    },
+    {
+        "paper_id": KRAMVIG,
+        "title": "Storytelling as a Means of Indigenous Knowledge Production",
+        "abstract": (
+            "Examines storytelling as a S\u00e1mi research methodology that challenges "
+            "Western epistemological frameworks. Through narrative analysis "
+            "and relational ontology, the paper centres indigenous ways of knowing "
+            "and argues for methodological pluralism in social sciences research."
+        ),
+        "year": 2014,
+        "citation_count": 55,
+        "authors": ["Britt Kramvig"],
+        "venue": "AlterNative: An International Journal of Indigenous Peoples",
+        "fields": ["Indigenous Studies", "Methodology", "Epistemology"],
+        "source": "seed",
+    },
+]
+
+
+# ── Query cases ────────────────────────────────────────────────────────
+
+@dataclass
+class QueryCase:
+    """A gold-standard retrieval query with expected results."""
+
+    query_id: str
+    query: str
+    relevant: List[str] = field(default_factory=list)
+    highly_relevant: List[str] = field(default_factory=list)
+    distractors: List[str] = field(default_factory=list)
+    expect_empty: bool = False
+
+
+RETRIEVAL_GOLD: List[QueryCase] = [
+    # ── Harvey domain ──────────────────────────────────────────────────
+    QueryCase(
+        query_id="harvey_neoliberalism",
+        query="What is Harvey's critique of neoliberalism?",
+        relevant=[HARVEY_NEOLIBERALISM],
+        highly_relevant=[HARVEY_NEOLIBERALISM],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    QueryCase(
+        query_id="accumulation_dispossession",
+        query="accumulation by dispossession and capitalist expansion",
+        relevant=[HARVEY_IMPERIALISM],
+        highly_relevant=[HARVEY_IMPERIALISM],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    QueryCase(
+        query_id="right_to_city",
+        query="urban social movements and the right to the city",
+        relevant=[HARVEY_REBEL_CITIES],
+        highly_relevant=[HARVEY_REBEL_CITIES],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    QueryCase(
+        query_id="time_space_compression",
+        query="time-space compression and postmodern cultural change",
+        relevant=[HARVEY_POSTMODERNITY],
+        highly_relevant=[HARVEY_POSTMODERNITY],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    QueryCase(
+        query_id="urban_marxism",
+        query="Marxist analysis of urban inequality and spatial justice",
+        relevant=[HARVEY_SOCIAL_JUSTICE],
+        highly_relevant=[HARVEY_SOCIAL_JUSTICE],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    # ── Cross-Harvey: multi-paper recall ───────────────────────────────
+    QueryCase(
+        query_id="harvey_political_economy",
+        query="David Harvey political economy and capital accumulation",
+        relevant=[HARVEY_NEOLIBERALISM, HARVEY_IMPERIALISM, HARVEY_POSTMODERNITY],
+        highly_relevant=[HARVEY_NEOLIBERALISM, HARVEY_IMPERIALISM],
+        distractors=[GRANOVETTER, KRAMVIG],
+    ),
+    # ── Granovetter domain ─────────────────────────────────────────────
+    QueryCase(
+        query_id="weak_ties",
+        query="weak ties in social networks and information diffusion",
+        relevant=[GRANOVETTER],
+        highly_relevant=[GRANOVETTER],
+        distractors=ALL_HARVEY,
+    ),
+    QueryCase(
+        query_id="job_search_networks",
+        query="how do people find jobs through social contacts and acquaintances",
+        relevant=[GRANOVETTER],
+        highly_relevant=[GRANOVETTER],
+        distractors=ALL_HARVEY,
+    ),
+    # ── Kramvig domain ─────────────────────────────────────────────────
+    QueryCase(
+        query_id="sami_methodology",
+        query="Sámi research methodology and indigenous epistemology",
+        relevant=[KRAMVIG],
+        highly_relevant=[KRAMVIG],
+        distractors=ALL_HARVEY + [GRANOVETTER],
+    ),
+    QueryCase(
+        query_id="indigenous_storytelling",
+        query="storytelling as a way of knowing in indigenous communities",
+        relevant=[KRAMVIG],
+        highly_relevant=[KRAMVIG],
+        distractors=ALL_HARVEY + [GRANOVETTER],
+    ),
+    # ── Cross-domain: nothing in corpus ────────────────────────────────
+    QueryCase(
+        query_id="cyborg_feminism",
+        query="cyborg feminism and science technology studies",
+        expect_empty=True,
+    ),
+]

--- a/tests/eval/test_context_boosting.py
+++ b/tests/eval/test_context_boosting.py
@@ -1,0 +1,218 @@
+"""CPU-only tests for context-based relevance boosting in _search_local.
+
+Tests the boost logic (research_agent.py:860-898) using mocked vector
+store and embedder. No GPU or real models needed.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from research_agent.agents.research_agent import AgentConfig
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _make_agent(config=None):
+    """Build a minimal ResearchAgent with mocked store + embedder."""
+    from research_agent.agents.research_agent import ResearchAgent
+
+    agent = ResearchAgent.__new__(ResearchAgent)
+    agent.model = None
+    agent._pipeline = {}
+    agent.provider = "none"
+    agent._load_model_on_demand = False
+    agent.use_ollama = False
+    agent.config = config or AgentConfig(max_local_results=10)
+
+    # Mock embedder — returns a zero vector
+    agent.embedder = MagicMock()
+    agent.embedder.embed_query.return_value = [0.0] * 768
+
+    return agent
+
+
+def _make_search_results(papers):
+    """Build a mock search() return value from paper dicts.
+
+    Each paper dict must have: paper_id, title, authors, distance.
+    """
+    return {
+        "documents": [p.get("content", f"Content of {p['title']}") for p in papers],
+        "metadatas": [
+            {
+                "paper_id": p["paper_id"],
+                "title": p["title"],
+                "authors": p.get("authors", ""),
+            }
+            for p in papers
+        ],
+        "distances": [p["distance"] for p in papers],
+    }
+
+
+_EMPTY = {"documents": [], "metadatas": [], "distances": []}
+
+
+def _wire_store(agent, paper_results, context_paper=None):
+    """Wire up mock vector store with canned search results."""
+    store = MagicMock()
+    store.search.side_effect = lambda **kwargs: (
+        paper_results if kwargs.get("collection") == "papers" else _EMPTY
+    )
+    store.get_paper.return_value = context_paper
+    agent.vector_store = store
+
+
+def _make_state(query, **overrides):
+    state = {
+        "messages": [],
+        "current_query": query,
+        "search_query": query,
+        "query_type": "literature_review",
+        "local_results": [],
+        "external_results": [],
+        "should_search_external": True,
+        "candidates_for_ingestion": [],
+        "final_answer": "",
+        "error": None,
+        "current_researcher": None,
+        "current_paper_id": None,
+        "auth_context_items": None,
+        "chat_context_items": None,
+    }
+    state.update(overrides)
+    return state
+
+
+def _find_result(results, paper_id):
+    for r in results:
+        if r["paper_id"] == paper_id:
+            return r
+    return None
+
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.eval
+async def test_researcher_boost_reorders():
+    """Researcher context (+0.15) should reorder results when appropriate."""
+    agent = _make_agent()
+    papers = [
+        {"paper_id": "other", "title": "Other Paper", "authors": "Jane Doe",
+         "distance": 0.20},  # raw relevance = 0.80
+        {"paper_id": "harvey", "title": "Harvey Paper", "authors": "David Harvey",
+         "distance": 0.30},  # raw relevance = 0.70
+    ]
+    _wire_store(agent, _make_search_results(papers))
+
+    state = _make_state("neoliberalism", current_researcher="David Harvey")
+    result = await agent._search_local(state)
+    results = result["local_results"]
+
+    harvey = _find_result(results, "harvey")
+    other = _find_result(results, "other")
+    assert harvey is not None
+    assert other is not None
+
+    # After boost: Harvey = 0.70 + 0.15 = 0.85 > Other = 0.80
+    assert harvey["relevance_score"] == pytest.approx(0.85, abs=1e-6)
+    assert harvey["context_match"] == "researcher"
+    assert results[0]["paper_id"] == "harvey"
+
+
+@pytest.mark.eval
+async def test_selected_paper_boost():
+    """Selected paper gets highest boost (+0.30 = boost_amount * 2)."""
+    agent = _make_agent()
+    papers = [
+        {"paper_id": "other", "title": "Other", "authors": "X",
+         "distance": 0.15},  # raw = 0.85
+        {"paper_id": "selected", "title": "Selected", "authors": "Y",
+         "distance": 0.40},  # raw = 0.60
+    ]
+    context_paper = {
+        "paper_id": "selected",
+        "metadata": {"authors": "Y", "title": "Selected"},
+        "chunks": ["content"],
+    }
+    _wire_store(agent, _make_search_results(papers), context_paper=context_paper)
+
+    state = _make_state("test", current_paper_id="selected")
+    result = await agent._search_local(state)
+    results = result["local_results"]
+
+    selected = _find_result(results, "selected")
+    assert selected is not None
+    # 0.60 + 0.30 = 0.90
+    assert selected["relevance_score"] == pytest.approx(0.90, abs=1e-6)
+    assert selected["context_match"] == "selected_paper"
+
+
+@pytest.mark.eval
+async def test_coauthor_boost_smaller_than_researcher():
+    """Co-author boost (+0.075) is half of researcher boost."""
+    agent = _make_agent()
+    papers = [
+        {"paper_id": "coauthor_paper", "title": "Co-Author Work",
+         "authors": "Neil Smith", "distance": 0.40},  # raw = 0.60
+    ]
+    # The selected paper has authors "David Harvey, Neil Smith"
+    context_paper = {
+        "paper_id": "selected",
+        "metadata": {"authors": "David Harvey, Neil Smith", "title": "Selected"},
+        "chunks": ["content"],
+    }
+    _wire_store(agent, _make_search_results(papers), context_paper=context_paper)
+
+    state = _make_state("test", current_paper_id="selected")
+    result = await agent._search_local(state)
+    results = result["local_results"]
+
+    coauthor = _find_result(results, "coauthor_paper")
+    assert coauthor is not None
+    # 0.60 + 0.075 = 0.675
+    assert coauthor["relevance_score"] == pytest.approx(0.675, abs=1e-6)
+    assert coauthor["context_match"] == "related_author"
+
+
+@pytest.mark.eval
+async def test_no_boost_without_context():
+    """Without researcher/paper context, scores stay at raw values."""
+    agent = _make_agent()
+    papers = [
+        {"paper_id": "p1", "title": "Paper 1", "authors": "A", "distance": 0.20},
+        {"paper_id": "p2", "title": "Paper 2", "authors": "B", "distance": 0.30},
+    ]
+    _wire_store(agent, _make_search_results(papers))
+
+    state = _make_state("test")  # no current_researcher, no current_paper_id
+    result = await agent._search_local(state)
+    results = result["local_results"]
+
+    for r in results:
+        assert "context_match" not in r
+    assert _find_result(results, "p1")["relevance_score"] == pytest.approx(0.80, abs=1e-6)
+    assert _find_result(results, "p2")["relevance_score"] == pytest.approx(0.70, abs=1e-6)
+
+
+@pytest.mark.eval
+async def test_score_capped_at_1():
+    """Boosted relevance score never exceeds 1.0."""
+    agent = _make_agent()
+    papers = [
+        {"paper_id": "high", "title": "High Score", "authors": "David Harvey",
+         "distance": 0.02},  # raw = 0.98
+    ]
+    _wire_store(agent, _make_search_results(papers))
+
+    state = _make_state("test", current_researcher="David Harvey")
+    result = await agent._search_local(state)
+    results = result["local_results"]
+
+    high = _find_result(results, "high")
+    assert high is not None
+    # 0.98 + 0.15 = 1.13, but capped to 1.0
+    assert high["relevance_score"] <= 1.0
+    assert high["relevance_score"] == pytest.approx(1.0, abs=1e-6)

--- a/tests/eval/test_reranker_quality.py
+++ b/tests/eval/test_reranker_quality.py
@@ -1,0 +1,146 @@
+"""Reranker quality tests: does the cross-encoder improve result ordering?
+
+CPU test: verifies surface-match-wins-without-reranker using fake embeddings.
+GPU tests: verifies reranker promotes semantic matches using real models.
+"""
+
+import pytest
+
+from research_agent.db.vector_store import ResearchVectorStore
+
+
+# ── CPU: Surface match wins without reranker ──────────────────────────
+
+
+@pytest.mark.eval
+def test_surface_match_wins_without_reranker(tmp_path):
+    """Without a reranker, keyword-stuffed doc beats semantic doc by cosine."""
+    store = ResearchVectorStore(
+        persist_dir=str(tmp_path / "chroma"),
+        metadata_store_path=None,
+    )
+
+    # Use 768d embeddings with controlled cosine distances
+    # query_emb: mostly dimension 0
+    query_emb = [1.0] + [0.0] * 767
+
+    # surface_emb: very close to query in embedding space
+    surface_emb = [0.99] + [0.14] + [0.0] * 766
+
+    # deep_emb: further from query in embedding space
+    deep_emb = [0.70] + [0.71] + [0.0] * 766
+
+    store.papers.add(
+        ids=["surface_chunk_0", "deep_chunk_0"],
+        embeddings=[surface_emb, deep_emb],
+        documents=[
+            "Neoliberalism neoliberalism neoliberalism keywords keywords",
+            (
+                "Harvey's analysis reveals how the capitalist state restructures "
+                "itself through class power, removing social protections and "
+                "deregulating labour markets under the guise of economic freedom."
+            ),
+        ],
+        metadatas=[
+            {"paper_id": "surface_paper", "title": "Surface Paper", "chunk_index": 0},
+            {"paper_id": "deep_paper", "title": "Deep Paper", "chunk_index": 0},
+        ],
+    )
+
+    result = store.search(query_embedding=query_emb, collection="papers", n_results=2)
+    assert result["ids"][0] == "surface_chunk_0", (
+        "Without reranker, surface match should win by cosine distance"
+    )
+
+
+# ── GPU: Reranker promotes semantic match ─────────────────────────────
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+def test_reranker_promotes_semantic_match(tmp_path, require_gpu):
+    """Cross-encoder should rerank the semantic doc above the keyword-stuffed one."""
+    from research_agent.models.reranker import Reranker
+
+    store = ResearchVectorStore(
+        persist_dir=str(tmp_path / "chroma"),
+        metadata_store_path=None,
+    )
+    reranker = Reranker(model_name="BAAI/bge-reranker-base")
+
+    query_emb = [1.0] + [0.0] * 767
+    surface_emb = [0.99] + [0.14] + [0.0] * 766
+    deep_emb = [0.70] + [0.71] + [0.0] * 766
+
+    store.papers.add(
+        ids=["surface_chunk_0", "deep_chunk_0"],
+        embeddings=[surface_emb, deep_emb],
+        documents=[
+            "Neoliberalism neoliberalism neoliberalism keywords keywords",
+            (
+                "Harvey's analysis reveals how the capitalist state restructures "
+                "itself through class power, removing social protections and "
+                "deregulating labour markets under the guise of economic freedom."
+            ),
+        ],
+        metadatas=[
+            {"paper_id": "surface_paper", "title": "Surface Paper", "chunk_index": 0},
+            {"paper_id": "deep_paper", "title": "Deep Paper", "chunk_index": 0},
+        ],
+    )
+
+    result = store.search(
+        query_embedding=query_emb,
+        query_text="Harvey's critique of neoliberalism and class power",
+        collection="papers",
+        n_results=2,
+        reranker=reranker,
+    )
+    assert result["ids"][0] == "deep_chunk_0", (
+        f"Reranker should promote deep match. Got: {result['ids']}"
+    )
+    assert "rerank_scores" in result
+    assert result["rerank_scores"][0] > result["rerank_scores"][1]
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+def test_reranker_does_not_degrade_seed_corpus(populated_store):
+    """Reranking should never push the correct paper below rank 3."""
+    from research_agent.models.reranker import Reranker
+    from tests.eval.corpus import RETRIEVAL_GOLD
+    from tests.eval.conftest import retrieve_paper_ids
+
+    store, embedder = populated_store
+    reranker = Reranker(model_name="BAAI/bge-reranker-base")
+
+    for case in RETRIEVAL_GOLD:
+        if not case.highly_relevant or case.expect_empty:
+            continue
+
+        embedding = embedder.embed_query(case.query)
+
+        # With reranker
+        reranked = store.search(
+            query_embedding=embedding,
+            query_text=case.query,
+            collection="papers",
+            n_results=15,
+            reranker=reranker,
+        )
+        # Deduplicate to paper_ids
+        seen = []
+        for meta in reranked.get("metadatas", []):
+            pid = meta.get("paper_id", "")
+            if pid and pid not in seen:
+                seen.append(pid)
+            if len(seen) >= 5:
+                break
+
+        target = case.highly_relevant[0]
+        if target in seen:
+            rank = seen.index(target) + 1
+            assert rank <= 3, (
+                f"[{case.query_id}] Reranker pushed {target!r} to rank {rank}. "
+                f"Results: {seen}"
+            )

--- a/tests/eval/test_retrieval_quality.py
+++ b/tests/eval/test_retrieval_quality.py
@@ -1,0 +1,119 @@
+"""Retrieval quality tests using real embeddings on the 7-paper seed corpus.
+
+All tests require GPU (real BAAI/bge-base-en-v1.5 embedder).
+"""
+
+from typing import List
+
+import pytest
+
+from tests.eval.corpus import RETRIEVAL_GOLD, QueryCase
+from tests.eval.conftest import retrieve_paper_ids
+
+
+# ── Metric helpers ─────────────────────────────────────────────────────
+
+
+def recall_at_k(results: List[str], relevant: List[str], k: int) -> float:
+    """Fraction of relevant paper_ids found in top-k results."""
+    if not relevant:
+        return 1.0
+    top_k = set(results[:k])
+    return len(top_k & set(relevant)) / len(relevant)
+
+
+def reciprocal_rank(results: List[str], relevant: List[str]) -> float:
+    """1/rank of the first relevant result; 0 if none found."""
+    for rank, pid in enumerate(results, 1):
+        if pid in relevant:
+            return 1.0 / rank
+    return 0.0
+
+
+# ── Parametrized test cases ───────────────────────────────────────────
+
+_single_relevant = [c for c in RETRIEVAL_GOLD if c.highly_relevant]
+_multi_relevant = [c for c in RETRIEVAL_GOLD if len(c.relevant) > 1]
+_with_distractors = [c for c in RETRIEVAL_GOLD if c.distractors and c.highly_relevant]
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+@pytest.mark.parametrize("case", _single_relevant, ids=lambda c: c.query_id)
+def test_recall_at_1(populated_store, case: QueryCase):
+    """The highly_relevant paper must appear at rank 1."""
+    store, embedder = populated_store
+    results = retrieve_paper_ids(store, embedder, case.query, k=5)
+    rr = reciprocal_rank(results, case.highly_relevant)
+    assert rr >= 1.0, (
+        f"[{case.query_id}] Expected {case.highly_relevant[0]!r} at rank 1, "
+        f"got: {results}"
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+@pytest.mark.parametrize("case", _multi_relevant, ids=lambda c: c.query_id)
+def test_recall_at_3_multi_paper(populated_store, case: QueryCase):
+    """For multi-paper queries, at least half of relevant papers in top 3."""
+    store, embedder = populated_store
+    results = retrieve_paper_ids(store, embedder, case.query, k=5)
+    r3 = recall_at_k(results, case.relevant, k=3)
+    assert r3 >= 0.5, (
+        f"[{case.query_id}] Recall@3={r3:.2f}, got {results}, wanted {case.relevant}"
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+@pytest.mark.parametrize("case", _with_distractors, ids=lambda c: c.query_id)
+def test_distractor_suppression(populated_store, case: QueryCase):
+    """Distractors from other clusters should not outrank the relevant paper."""
+    store, embedder = populated_store
+    results = retrieve_paper_ids(store, embedder, case.query, k=5)
+    target = case.highly_relevant[0]
+    if target not in results:
+        pytest.skip("Relevant paper not found at all — covered by recall test")
+    relevant_rank = results.index(target) + 1
+    for distractor in case.distractors:
+        if distractor in results:
+            distractor_rank = results.index(distractor) + 1
+            assert distractor_rank > relevant_rank, (
+                f"[{case.query_id}] Distractor {distractor!r} (rank {distractor_rank}) "
+                f"outranks {target!r} (rank {relevant_rank}). "
+                f"Full results: {results}"
+            )
+
+
+@pytest.mark.gpu
+@pytest.mark.eval
+def test_mrr_above_threshold(populated_store):
+    """MRR across all single-relevant queries must be >= 0.70."""
+    store, embedder = populated_store
+    cases = [c for c in RETRIEVAL_GOLD if len(c.relevant) == 1 and not c.expect_empty]
+    scores = []
+    for case in cases:
+        results = retrieve_paper_ids(store, embedder, case.query, k=5)
+        scores.append(reciprocal_rank(results, case.relevant))
+    mrr = sum(scores) / len(scores) if scores else 0.0
+    print(f"\nMRR over {len(scores)} queries: {mrr:.3f}")
+    for case, score in zip(cases, scores):
+        print(f"  {case.query_id}: RR={score:.2f}")
+    assert mrr >= 0.70, f"MRR {mrr:.3f} below threshold 0.70"
+
+
+# ── Edge case (CPU-safe) ──────────────────────────────────────────────
+
+
+@pytest.mark.eval
+def test_empty_corpus_returns_nothing(tmp_path):
+    """Search on empty store returns empty results."""
+    from research_agent.db.vector_store import ResearchVectorStore
+
+    store = ResearchVectorStore(
+        persist_dir=str(tmp_path / "chroma"),
+        metadata_store_path=None,
+    )
+    result = store.search(query_embedding=[0.0] * 768, collection="papers", n_results=5)
+    assert result["ids"] == []
+    assert result["documents"] == []

--- a/tests/eval/test_synthesis_unit.py
+++ b/tests/eval/test_synthesis_unit.py
@@ -1,0 +1,167 @@
+"""CPU-only tests for query classification heuristics and prompt construction.
+
+No LLM calls — agent.model is always None.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_agent.agents.research_agent import AgentConfig
+
+
+# ── Agent factory (no model, no vector store) ─────────────────────────
+
+def _make_agent(**overrides):
+    """Build a minimal ResearchAgent with no model loaded."""
+    from research_agent.agents.research_agent import ResearchAgent
+
+    agent = ResearchAgent.__new__(ResearchAgent)
+    agent.model = None
+    agent._pipeline = {}
+    agent.provider = "none"
+    agent._load_model_on_demand = False
+    agent.use_ollama = False
+    agent.vector_store = None
+    agent.embedder = None
+    agent.config = AgentConfig()
+    for k, v in overrides.items():
+        setattr(agent, k, v)
+    return agent
+
+
+def _make_state(query, **overrides):
+    state = {
+        "messages": [],
+        "current_query": query,
+        "search_query": "",
+        "query_type": "",
+        "local_results": [],
+        "external_results": [],
+        "should_search_external": False,
+        "candidates_for_ingestion": [],
+        "final_answer": "",
+        "error": None,
+        "current_researcher": None,
+        "current_paper_id": None,
+        "auth_context_items": None,
+        "chat_context_items": None,
+    }
+    state.update(overrides)
+    return state
+
+
+# ── Query classification heuristics ───────────────────────────────────
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize(
+    "query,expected_type",
+    [
+        ("review of literature on neoliberalism", "literature_review"),
+        ("key papers on accumulation by dispossession", "literature_review"),
+        ("what is the state of research on weak ties", "literature_review"),
+        ("overview of urban geography", "literature_review"),
+        ("what is accumulation by dispossession", "factual"),
+        ("tell me about Harvey's concept of space", "factual"),
+        ("what do you know about Kramvig's work", "factual"),
+        ("compare Harvey and Bourdieu on capital", "analysis"),
+        ("relationship between neoliberalism and inequality", "analysis"),
+        ("hi there", "general"),
+        ("hello", "general"),
+    ],
+)
+async def test_query_classification_heuristics(query, expected_type):
+    agent = _make_agent()
+    state = _make_state(query)
+    result = await agent._understand_query(state)
+    assert result["query_type"] == expected_type, (
+        f"Query {query!r} -> got {result['query_type']!r}, expected {expected_type!r}"
+    )
+
+
+# ── Search keywords not empty for research queries ────────────────────
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize(
+    "query",
+    [
+        "What is accumulation by dispossession?",
+        "David Harvey's work on neoliberalism",
+        "Compare structuralism and post-structuralism",
+        "overview of indigenous research methodology",
+    ],
+)
+async def test_search_query_not_empty_for_research(query):
+    agent = _make_agent()
+    state = _make_state(query)
+    result = await agent._understand_query(state)
+    # Without LLM, _extract_search_keywords falls back to the query itself
+    assert result["search_query"] != "", (
+        f"search_query should not be empty for: {query!r}"
+    )
+
+
+# ── Synthesis prompt structure ────────────────────────────────────────
+
+
+@pytest.mark.eval
+@pytest.mark.parametrize("query_type", ["literature_review", "factual", "analysis"])
+def test_synthesis_prompt_contains_citations(query_type):
+    agent = _make_agent()
+    results = [
+        {
+            "title": "A Brief History of Neoliberalism",
+            "authors": "David Harvey",
+            "year": 2005,
+            "content": "Neoliberalism is a theory of political economic practices...",
+            "source": "local_kb",
+        },
+    ]
+    prompt = agent._build_synthesis_prompt("neoliberalism", query_type, results)
+    assert "[1]" in prompt
+    assert "A Brief History of Neoliberalism" in prompt
+    assert "neoliberalism" in prompt.lower()
+
+
+@pytest.mark.eval
+def test_synthesis_prompt_sequential_numbering():
+    agent = _make_agent()
+    results = [
+        {"title": f"Paper {i}", "content": f"Content about topic {i}", "source": "local_kb"}
+        for i in range(1, 6)
+    ]
+    prompt = agent._build_synthesis_prompt("test query", "literature_review", results)
+    for i in range(1, 6):
+        assert f"[{i}]" in prompt, f"Missing citation [{i}] in prompt"
+
+
+# ── No-source handling ────────────────────────────────────────────────
+
+
+@pytest.mark.eval
+async def test_no_sources_general_returns_helpful():
+    """General query + no results -> helpful non-error response."""
+    agent = _make_agent()
+    state = _make_state("hello", query_type="general")
+    result = await agent._synthesize(state)
+    answer = result["final_answer"]
+    assert len(answer) > 0
+    assert "error" not in answer.lower()
+    assert any(
+        word in answer.lower()
+        for word in ["research", "help", "knowledge", "explore", "assistant"]
+    )
+
+
+@pytest.mark.eval
+async def test_no_sources_research_uses_fallback():
+    """Research query + no LLM + no results -> fallback message."""
+    agent = _make_agent()
+    state = _make_state(
+        "review of neoliberalism literature",
+        query_type="literature_review",
+    )
+    result = await agent._synthesize(state)
+    assert "No retrieved sources" in result["final_answer"]

--- a/tests/test_claude_tools.py
+++ b/tests/test_claude_tools.py
@@ -1,0 +1,474 @@
+"""Tests for Claude native tool-use integration.
+
+All tests mock the Anthropic SDK — zero API credits burned.
+
+Covers:
+- is_claude property detection
+- Tool schema definitions
+- Tool execution dispatch
+- Full tool-use loop with mocked client
+- Result format parity with LangGraph path
+- Fallback on import error or API error
+- connect_provider preserves canonical_provider
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_model_loading():
+    """Prevent actual model loading in tests."""
+    from research_agent.models.llm_utils import VRAMConstraintError
+
+    with patch("research_agent.agents.research_agent.get_qlora_pipeline") as mock_qlora, \
+         patch("research_agent.agents.research_agent.get_ollama_pipeline") as mock_ollama:
+        mock_qlora.side_effect = VRAMConstraintError("Model loading disabled in tests")
+        mock_ollama.side_effect = Exception("Ollama disabled in tests")
+        yield
+
+
+def _make_agent(**kwargs):
+    """Create a minimal ResearchAgent for testing."""
+    from research_agent.agents.research_agent import ResearchAgent
+    return ResearchAgent(use_ollama=False, **kwargs)
+
+
+def _make_claude_agent():
+    """Create a ResearchAgent that looks like an Anthropic provider."""
+    agent = _make_agent(
+        canonical_provider="anthropic",
+        provider="openai",
+        openai_api_key="sk-ant-test-key",
+        openai_base_url="https://api.anthropic.com/v1/",
+        openai_model="claude-sonnet-4-6",
+        openai_models=["claude-sonnet-4-6", "claude-haiku-4-5"],
+    )
+    # Inject a mock model
+    mock_model = MagicMock()
+    mock_model.model_name = "claude-sonnet-4-6"
+    mock_model.generate.return_value = "mock response"
+    agent.model = mock_model
+    return agent
+
+
+def _make_text_block(text):
+    """Create a mock Anthropic TextBlock."""
+    block = SimpleNamespace(type="text", text=text)
+    return block
+
+
+def _make_tool_use_block(tool_id, name, input_data):
+    """Create a mock Anthropic ToolUseBlock."""
+    return SimpleNamespace(
+        type="tool_use",
+        id=tool_id,
+        name=name,
+        input=input_data,
+    )
+
+
+def _make_response(content, stop_reason="end_turn"):
+    """Create a mock Anthropic Message response."""
+    return SimpleNamespace(
+        content=content,
+        stop_reason=stop_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_claude detection
+# ---------------------------------------------------------------------------
+
+class TestIsClaudeDetection:
+    def test_is_claude_true_for_anthropic(self):
+        agent = _make_claude_agent()
+        assert agent.is_claude is True
+
+    def test_is_claude_false_for_groq(self):
+        agent = _make_agent(
+            canonical_provider="groq",
+            provider="openai",
+            openai_api_key="gsk-test",
+        )
+        assert agent.is_claude is False
+
+    def test_is_claude_false_without_key(self):
+        agent = _make_agent(
+            canonical_provider="anthropic",
+            provider="openai",
+            openai_api_key=None,
+        )
+        assert agent.is_claude is False
+
+    def test_is_claude_false_default_provider(self):
+        agent = _make_agent()
+        assert agent.is_claude is False
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+class TestToolDefinitions:
+    def test_tool_count(self):
+        agent = _make_claude_agent()
+        tools = agent._get_claude_tool_definitions()
+        assert len(tools) == 3
+
+    def test_tool_names(self):
+        agent = _make_claude_agent()
+        tools = agent._get_claude_tool_definitions()
+        names = {t["name"] for t in tools}
+        assert names == {"search_local_kb", "search_academic", "search_web"}
+
+    def test_tool_schemas_valid(self):
+        agent = _make_claude_agent()
+        tools = agent._get_claude_tool_definitions()
+        for tool in tools:
+            assert "name" in tool
+            assert "description" in tool
+            assert "input_schema" in tool
+            schema = tool["input_schema"]
+            assert schema["type"] == "object"
+            assert "properties" in schema
+            assert "required" in schema
+            assert "query" in schema["required"]
+
+    def test_academic_tool_has_year_params(self):
+        agent = _make_claude_agent()
+        tools = agent._get_claude_tool_definitions()
+        academic = next(t for t in tools if t["name"] == "search_academic")
+        props = academic["input_schema"]["properties"]
+        assert "year_from" in props
+        assert "year_to" in props
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+class TestSystemPrompt:
+    def test_basic_prompt(self):
+        agent = _make_claude_agent()
+        prompt = agent._build_claude_system_prompt({})
+        assert "research assistant" in prompt
+        assert "knowledge base" in prompt
+        assert "[1]" in prompt
+
+    def test_prompt_with_researcher_context(self):
+        agent = _make_claude_agent()
+        prompt = agent._build_claude_system_prompt({"researcher": "David Harvey"})
+        assert "David Harvey" in prompt
+
+    def test_prompt_with_pinned_topics(self):
+        agent = _make_claude_agent()
+        prompt = agent._build_claude_system_prompt(
+            {"auth_items": ["neoliberalism", "urbanization"]}
+        )
+        assert "neoliberalism" in prompt
+        assert "urbanization" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Tool execution dispatch
+# ---------------------------------------------------------------------------
+
+class TestToolExecution:
+    @pytest.mark.asyncio
+    async def test_execute_local_kb_dispatches(self):
+        agent = _make_claude_agent()
+        # Mock vector store and embedder
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query.return_value = [0.1] * 768
+
+        mock_store = MagicMock()
+        mock_store.search.return_value = {
+            "documents": ["Test content about neoliberalism"],
+            "metadatas": [{"title": "Test Paper", "authors": "Harvey", "year": 2005, "paper_id": "test-1"}],
+            "distances": [0.3],
+        }
+
+        agent.embedder = mock_embedder
+        agent.vector_store = mock_store
+
+        local_results = []
+        result = await agent._execute_claude_tool(
+            "search_local_kb", {"query": "neoliberalism"},
+            local_results, [], {},
+        )
+        assert len(local_results) > 0
+        assert "local knowledge base" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_academic_dispatches(self):
+        agent = _make_claude_agent()
+        mock_search = AsyncMock()
+        mock_paper = SimpleNamespace(
+            title="Test Paper", authors=["Author A"], year=2020,
+            abstract="Abstract", paper_id="p1", doi="10.1/test",
+            citation_count=50, url="http://example.com",
+        )
+        mock_search.search_openalex = AsyncMock(return_value=[mock_paper])
+        mock_search.search_semantic_scholar = AsyncMock(return_value=[])
+        mock_search.search_core = AsyncMock(return_value=[])
+        agent.academic_search = mock_search
+
+        external_results = []
+        result = await agent._execute_claude_tool(
+            "search_academic", {"query": "test query"},
+            [], external_results, {},
+        )
+        assert len(external_results) == 1
+        assert external_results[0]["title"] == "Test Paper"
+        assert "academic" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_web_dispatches(self):
+        agent = _make_claude_agent()
+        mock_web = AsyncMock()
+        mock_web.search = AsyncMock(return_value=[
+            {"title": "Web Result", "url": "http://example.com", "snippet": "Content"},
+        ])
+        agent.web_search = mock_web
+
+        external_results = []
+        result = await agent._execute_claude_tool(
+            "search_web", {"query": "test"},
+            [], external_results, {},
+        )
+        assert len(external_results) == 1
+        assert "web" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_unknown_tool(self):
+        agent = _make_claude_agent()
+        result = await agent._execute_claude_tool(
+            "nonexistent_tool", {}, [], [], {},
+        )
+        assert "Unknown tool" in result
+
+
+# ---------------------------------------------------------------------------
+# Full tool-use loop
+# ---------------------------------------------------------------------------
+
+class TestRunWithClaudeTools:
+    @pytest.mark.asyncio
+    async def test_greeting_no_tools(self):
+        """Claude answers a greeting without calling any tools."""
+        agent = _make_claude_agent()
+
+        mock_response = _make_response(
+            content=[_make_text_block("Hello! How can I help you with your research?")],
+            stop_reason="end_turn",
+        )
+
+        with patch("anthropic.AsyncAnthropic") as MockClient:
+            instance = AsyncMock()
+            instance.messages.create = AsyncMock(return_value=mock_response)
+            MockClient.return_value = instance
+
+            result = await agent._run_with_claude_tools("Hello!")
+
+        assert result["answer"] == "Hello! How can I help you with your research?"
+        assert result["local_sources"] == 0
+        assert result["external_sources"] == 0
+        assert result["query"] == "Hello!"
+
+    @pytest.mark.asyncio
+    async def test_research_query_with_tool_calls(self):
+        """Claude calls search_local_kb, gets results, then synthesizes."""
+        agent = _make_claude_agent()
+        # Mock embedder + vector store for tool execution
+        agent.embedder = MagicMock()
+        agent.embedder.embed_query.return_value = [0.1] * 768
+        agent.vector_store = MagicMock()
+        agent.vector_store.search.return_value = {
+            "documents": ["Harvey critiques neoliberalism..."],
+            "metadatas": [{"title": "Brief History of Neoliberalism", "authors": "David Harvey", "year": 2005, "paper_id": "h1"}],
+            "distances": [0.2],
+        }
+
+        # First response: tool call
+        tool_response = _make_response(
+            content=[
+                _make_tool_use_block("call_1", "search_local_kb", {"query": "Harvey neoliberalism"}),
+            ],
+            stop_reason="tool_use",
+        )
+        # Second response: synthesis
+        synth_response = _make_response(
+            content=[_make_text_block("Harvey critiques neoliberalism as a class project [1].")],
+            stop_reason="end_turn",
+        )
+
+        with patch("anthropic.AsyncAnthropic") as MockClient:
+            instance = AsyncMock()
+            instance.messages.create = AsyncMock(side_effect=[tool_response, synth_response])
+            MockClient.return_value = instance
+
+            result = await agent._run_with_claude_tools(
+                "What does Harvey say about neoliberalism?"
+            )
+
+        assert "[1]" in result["answer"]
+        assert result["local_sources"] > 0
+        assert "query" in result
+        assert "sources" in result
+
+    @pytest.mark.asyncio
+    async def test_max_turns_safety(self):
+        """Verify MAX_TURNS prevents infinite loops."""
+        agent = _make_claude_agent()
+        agent.embedder = MagicMock()
+        agent.embedder.embed_query.return_value = [0.1] * 768
+        agent.vector_store = MagicMock()
+        agent.vector_store.search.return_value = {
+            "documents": [], "metadatas": [], "distances": [],
+        }
+
+        # Every response is a tool call — never end_turn
+        endless_response = _make_response(
+            content=[
+                _make_tool_use_block("call_n", "search_local_kb", {"query": "test"}),
+            ],
+            stop_reason="tool_use",
+        )
+
+        with patch("anthropic.AsyncAnthropic") as MockClient:
+            instance = AsyncMock()
+            instance.messages.create = AsyncMock(return_value=endless_response)
+            MockClient.return_value = instance
+
+            result = await agent._run_with_claude_tools("test")
+
+        assert "wasn't able to complete" in result["answer"]
+
+    @pytest.mark.asyncio
+    async def test_result_format_matches_langgraph(self):
+        """The result dict has the same keys as the LangGraph path."""
+        agent = _make_claude_agent()
+
+        mock_response = _make_response(
+            content=[_make_text_block("Test answer")],
+            stop_reason="end_turn",
+        )
+
+        with patch("anthropic.AsyncAnthropic") as MockClient:
+            instance = AsyncMock()
+            instance.messages.create = AsyncMock(return_value=mock_response)
+            MockClient.return_value = instance
+
+            result = await agent._run_with_claude_tools("test")
+
+        # These are the keys _run_async always returns
+        assert "query" in result
+        assert "answer" in result
+        assert "query_type" in result
+        assert "local_sources" in result
+        assert "external_sources" in result
+        assert "sources" in result
+        assert isinstance(result["sources"], list)
+
+
+# ---------------------------------------------------------------------------
+# Fallback behavior
+# ---------------------------------------------------------------------------
+
+class TestFallback:
+    @pytest.mark.asyncio
+    async def test_fallback_on_import_error(self):
+        """If anthropic not installed, falls back to LangGraph."""
+        agent = _make_claude_agent()
+
+        # Patch _run_with_claude_tools to raise ImportError
+        with patch.object(agent, "_run_with_claude_tools", side_effect=ImportError("No anthropic")):
+            # Mock the graph to prevent actual LangGraph execution
+            mock_state = {
+                "final_answer": "LangGraph answer",
+                "query_type": "general",
+                "local_results": [],
+                "external_results": [],
+                "error": None,
+            }
+            agent.graph = MagicMock()
+            agent.graph.ainvoke = AsyncMock(return_value=mock_state)
+
+            result = await agent._run_async("test query")
+
+        assert result["answer"] == "LangGraph answer"
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_api_error(self):
+        """If Claude API errors, falls back to LangGraph."""
+        agent = _make_claude_agent()
+
+        with patch.object(agent, "_run_with_claude_tools", side_effect=Exception("API 500")):
+            mock_state = {
+                "final_answer": "LangGraph fallback",
+                "query_type": "general",
+                "local_results": [],
+                "external_results": [],
+                "error": None,
+            }
+            agent.graph = MagicMock()
+            agent.graph.ainvoke = AsyncMock(return_value=mock_state)
+
+            result = await agent._run_async("test query")
+
+        assert result["answer"] == "LangGraph fallback"
+
+
+# ---------------------------------------------------------------------------
+# connect_provider preserves canonical
+# ---------------------------------------------------------------------------
+
+class TestConnectProvider:
+    def test_anthropic_byok_sets_canonical(self):
+        agent = _make_agent(provider="openai", openai_api_key="sk-temp")
+        mock_model = MagicMock()
+        agent.model = mock_model
+        agent._canonical_provider = "groq"  # Start as something else
+
+        with patch("research_agent.agents.research_agent.OpenAICompatibleModel"):
+            result = agent.connect_provider("anthropic", "sk-ant-test123")
+
+        assert result is True
+        assert agent._canonical_provider == "anthropic"
+        assert agent.is_claude is True
+
+    def test_groq_byok_not_claude(self):
+        agent = _make_agent(provider="openai", openai_api_key="sk-temp")
+
+        with patch("research_agent.agents.research_agent.OpenAICompatibleModel"):
+            agent.connect_provider("groq", "gsk-test123")
+
+        assert agent._canonical_provider == "groq"
+        assert agent.is_claude is False
+
+
+# ---------------------------------------------------------------------------
+# Format tool results
+# ---------------------------------------------------------------------------
+
+class TestFormatToolResults:
+    def test_empty_results(self):
+        agent = _make_claude_agent()
+        text = agent._format_tool_results([], "academic")
+        assert "No academic results found" in text
+
+    def test_formats_papers(self):
+        agent = _make_claude_agent()
+        results = [
+            {"title": "Test Paper", "authors": "Author A", "year": 2020, "content": "Some content"},
+        ]
+        text = agent._format_tool_results(results, "academic")
+        assert "[1] Test Paper" in text
+        assert "Author A" in text
+        assert "2020" in text

--- a/tests/test_core_search.py
+++ b/tests/test_core_search.py
@@ -1,0 +1,157 @@
+"""Tests for CORE API integration in AcademicSearchTools."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+SAMPLE_CORE_RESPONSE = {
+    "totalHits": 2,
+    "results": [
+        {
+            "id": 12345,
+            "title": "Indigenous Knowledge Systems in the Arctic",
+            "abstract": "This paper examines indigenous knowledge systems...",
+            "yearPublished": 2021,
+            "authors": [{"name": "Kramvig, B."}, {"name": "Kristoffersen, B."}],
+            "doi": "https://doi.org/10.1234/test.2021",
+            "downloadUrl": "https://core.ac.uk/download/pdf/12345.pdf",
+            "citationCount": 15,
+            "publisher": "Arctic Research Journal",
+            "sourceFulltextUrls": [],
+        },
+        {
+            "id": 67890,
+            "title": "Climate Adaptation in Northern Communities",
+            "abstract": "Northern communities face unique challenges...",
+            "yearPublished": 2020,
+            "authors": [{"name": "Harvey, D."}],
+            "doi": "10.5678/climate.2020",
+            "downloadUrl": None,
+            "citationCount": 8,
+            "publisher": None,
+            "sourceFulltextUrls": ["https://example.com/paper.pdf"],
+        },
+    ],
+}
+
+
+@pytest.fixture
+def mock_academic_search():
+    """Create AcademicSearchTools with mocked HTTP client."""
+    from research_agent.tools.academic_search import AcademicSearchTools
+    tools = AcademicSearchTools(config={"core": {"api_key": "test-key"}}, cache_enabled=False)
+    return tools
+
+
+class TestSearchCore:
+    @pytest.mark.asyncio
+    async def test_returns_papers(self, mock_academic_search):
+        """CORE search parses response into Paper objects."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("arctic indigenous knowledge")
+
+        assert len(papers) == 2
+        assert papers[0].title == "Indigenous Knowledge Systems in the Arctic"
+        assert papers[0].source == "core"
+        assert papers[0].doi == "10.1234/test.2021"  # stripped https://doi.org/
+        assert papers[0].year == 2021
+        assert len(papers[0].authors) == 2
+
+    @pytest.mark.asyncio
+    async def test_doi_without_prefix(self, mock_academic_search):
+        """DOIs without https://doi.org/ prefix are kept as-is."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("climate")
+
+        # Second paper has doi without prefix
+        assert papers[1].doi == "10.5678/climate.2020"
+
+    @pytest.mark.asyncio
+    async def test_fallback_download_url(self, mock_academic_search):
+        """Falls back to sourceFulltextUrls when downloadUrl is None."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_CORE_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("climate")
+
+        assert papers[1].open_access_url == "https://example.com/paper.pdf"
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty(self, mock_academic_search):
+        """HTTP errors return empty list."""
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(side_effect=Exception("Connection refused"))
+            mock_client.return_value = client
+
+            papers = await mock_academic_search.search_core("test query")
+
+        assert papers == []
+
+    @pytest.mark.asyncio
+    async def test_year_filter_in_query(self, mock_academic_search):
+        """Year filters are appended to query string."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(mock_academic_search, "_get_client") as mock_client:
+            client = AsyncMock()
+            client.get = AsyncMock(return_value=mock_resp)
+            mock_client.return_value = client
+
+            await mock_academic_search.search_core("test", from_year=2020, to_year=2023)
+
+            # Check the query parameter includes year filters
+            call_args = client.get.call_args
+            params = call_args.kwargs.get("params") or call_args[1].get("params")
+            assert "yearPublished>=2020" in params["q"]
+            assert "yearPublished<=2023" in params["q"]
+
+    @pytest.mark.asyncio
+    async def test_no_api_key(self):
+        """Works without API key (no Authorization header)."""
+        from research_agent.tools.academic_search import AcademicSearchTools
+        tools = AcademicSearchTools(config={}, cache_enabled=False)
+        assert tools._core_api_key is None
+
+    @pytest.mark.asyncio
+    async def test_caching(self):
+        """Cached results are returned without API call."""
+        from research_agent.tools.academic_search import AcademicSearchTools
+        tools = AcademicSearchTools(config={}, cache_enabled=True)
+
+        # Manually populate cache
+        from research_agent.utils.cache import make_cache_key
+        cache_key = make_cache_key("core_search", "test query", limit=20, from_year=None, to_year=None)
+        cached_papers = [{"title": "Cached Paper", "source": "core"}]
+        tools._cache.set(cache_key, cached_papers, ttl=3600)
+
+        papers = await tools.search_core("test query")
+        assert len(papers) == 1
+        assert papers[0]["title"] == "Cached Paper"

--- a/tests/test_enrichment_caching.py
+++ b/tests/test_enrichment_caching.py
@@ -1,0 +1,261 @@
+"""Tests for enrichment caching: AuthorPaper fields, ResearcherStore enrichment, and injection."""
+
+import json
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from research_agent.tools.researcher_lookup import AuthorPaper, ResearcherProfile
+from research_agent.db.researcher_store import ResearcherStore
+from research_agent.explorer.graph_builder import GraphBuilder
+
+
+# ---------------------------------------------------------------------------
+# AuthorPaper enrichment fields
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorPaperEnrichmentFields:
+    def test_fields_exist_and_default_to_none(self):
+        p = AuthorPaper(paper_id="p1", title="Test Paper")
+        assert p.oa_status is None
+        assert p.open_access_url is None
+        assert p.tldr is None
+
+    def test_fields_survive_to_dict(self):
+        p = AuthorPaper(
+            paper_id="p1",
+            title="Test Paper",
+            oa_status="gold",
+            open_access_url="https://example.com/pdf",
+            tldr="A short summary of the paper.",
+        )
+        d = p.to_dict()
+        assert d["oa_status"] == "gold"
+        assert d["open_access_url"] == "https://example.com/pdf"
+        assert d["tldr"] == "A short summary of the paper."
+
+    def test_source_defaults_to_unknown(self):
+        p = AuthorPaper(paper_id="p1", title="Test Paper")
+        assert p.source == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# ResearcherStore enrichment roundtrip
+# ---------------------------------------------------------------------------
+
+
+def _make_profile(name="Alice Smith", papers=None):
+    return ResearcherProfile(
+        name=name,
+        normalized_name=name.lower().strip(),
+        openalex_id="A111",
+        semantic_scholar_id="S222",
+        affiliations=["MIT"],
+        works_count=50,
+        citations_count=2000,
+        h_index=25,
+        fields=["Sociology"],
+        top_papers=papers or [
+            AuthorPaper(
+                paper_id="p1",
+                title="Paper One",
+                doi="10.1000/one",
+                oa_status="gold",
+                open_access_url="https://example.com/p1.pdf",
+                tldr="Summary of paper one.",
+            ),
+            AuthorPaper(
+                paper_id="p2",
+                title="Paper Two",
+                doi="10.1000/two",
+            ),
+        ],
+    )
+
+
+class TestResearcherStoreEnrichmentRoundtrip:
+    def setup_method(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.store = ResearcherStore(path=f"{self.tmpdir}/test.sqlite")
+
+    def test_paper_enrichment_fields_persist(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        loaded = self.store.load_researcher("alice smith")
+        assert loaded is not None
+        p1 = next(p for p in loaded.top_papers if p.paper_id == "p1")
+        assert p1.oa_status == "gold"
+        assert p1.open_access_url == "https://example.com/p1.pdf"
+        assert p1.tldr == "Summary of paper one."
+
+        p2 = next(p for p in loaded.top_papers if p.paper_id == "p2")
+        assert p2.oa_status is None
+        assert p2.open_access_url is None
+        assert p2.tldr is None
+
+    def test_enrichment_artifacts_save_and_load(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        embeddings = {"p1": [0.1] * 768, "p2": [0.2] * 768}
+        ref_map = {"10.1000/one": ["10.2000/ref1", "10.2000/ref2"]}
+        tldrs = {"p1": "Summary of paper one.", "p2": "Summary of paper two."}
+
+        self.store.save_researcher_enrichment(
+            "alice smith", embeddings=embeddings, ref_map=ref_map, tldrs=tldrs,
+        )
+
+        loaded_emb, loaded_ref, loaded_tldrs = self.store.load_researcher_enrichment(
+            "alice smith"
+        )
+        assert len(loaded_emb) == 2
+        assert len(loaded_emb["p1"]) == 768
+        assert loaded_ref == ref_map
+        assert loaded_tldrs == tldrs
+
+    def test_enrichment_empty_when_not_cached(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        emb, refs, tldrs = self.store.load_researcher_enrichment("alice smith")
+        assert emb == {}
+        assert refs == {}
+        assert tldrs == {}
+
+    def test_enrichment_upsert_overwrites(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+
+        self.store.save_enrichment("alice smith", "tldrs", {"p1": "old"})
+        self.store.save_enrichment("alice smith", "tldrs", {"p1": "new"})
+
+        loaded = self.store.load_enrichment("alice smith", "tldrs")
+        assert loaded == {"p1": "new"}
+
+    def test_enrichment_cascades_on_delete(self):
+        profile = _make_profile()
+        self.store.save_researcher(profile)
+        self.store.save_researcher_enrichment(
+            "alice smith", embeddings={"p1": [0.1]},
+        )
+
+        self.store.delete_researcher("alice smith")
+
+        emb, refs, tldrs = self.store.load_researcher_enrichment("alice smith")
+        assert emb == {}
+
+
+# ---------------------------------------------------------------------------
+# Schema migration
+# ---------------------------------------------------------------------------
+
+
+class TestResearcherStoreMigration:
+    def test_migration_adds_columns_to_existing_db(self):
+        """Simulate an old DB without enrichment columns and verify migration."""
+        tmpdir = tempfile.mkdtemp()
+        db_path = f"{tmpdir}/old.sqlite"
+
+        # Create old-style DB without enrichment columns
+        conn = sqlite3.connect(db_path)
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute("""
+            CREATE TABLE researchers (
+                normalized_name TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                openalex_id TEXT,
+                semantic_scholar_id TEXT,
+                affiliations TEXT,
+                works_count INTEGER DEFAULT 0,
+                citations_count INTEGER DEFAULT 0,
+                h_index INTEGER,
+                fields TEXT,
+                lookup_timestamp TEXT,
+                updated_at TEXT
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE researcher_papers (
+                researcher_name TEXT NOT NULL,
+                paper_id TEXT NOT NULL,
+                title TEXT, year INTEGER, citation_count INTEGER,
+                venue TEXT, doi TEXT, abstract TEXT, fields TEXT, source TEXT,
+                PRIMARY KEY (researcher_name, paper_id),
+                FOREIGN KEY (researcher_name) REFERENCES researchers(normalized_name) ON DELETE CASCADE
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE researcher_web_results (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                researcher_name TEXT NOT NULL,
+                title TEXT, url TEXT, snippet TEXT,
+                FOREIGN KEY (researcher_name) REFERENCES researchers(normalized_name) ON DELETE CASCADE
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+        # Now open with ResearcherStore — should migrate
+        store = ResearcherStore(path=db_path)
+
+        # Verify columns exist
+        conn = sqlite3.connect(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(researcher_papers)").fetchall()}
+        conn.close()
+        assert "oa_status" in cols
+        assert "open_access_url" in cols
+        assert "tldr" in cols
+
+        # Verify enrichment table exists
+        conn = sqlite3.connect(db_path)
+        tables = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()}
+        conn.close()
+        assert "researcher_enrichment" in tables
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    def test_graph_works_without_enrichment(self):
+        """Graph builder produces a valid graph even with no cached enrichment."""
+        gb = GraphBuilder()
+        profile = _make_profile()
+        gb.add_researcher(profile.to_dict())
+        for p in profile.top_papers:
+            pid = gb.add_paper(p)
+            gb.add_authorship_edge("researcher:A111", pid)
+        gb.build_structural_context()
+        # No enrichment injection — should still produce valid graph
+        data = gb.to_dict()
+        assert len(data["nodes"]) > 0
+        assert len(data["links"]) > 0
+
+    def test_inject_with_empty_enrichment(self):
+        """Injecting empty dicts is a no-op."""
+        gb = GraphBuilder()
+        profile = _make_profile()
+        gb.add_researcher(profile.to_dict())
+        for p in profile.top_papers:
+            pid = gb.add_paper(p)
+            gb.add_authorship_edge("researcher:A111", pid)
+        gb.build_structural_context()
+
+        # Empty dicts — should do nothing
+        gb.inject_embeddings({})
+        gb.inject_tldrs({})
+        gb.fill_citation_gaps({})
+
+        data = gb.to_dict()
+        assert len(data["nodes"]) > 0
+        # No semantic edges should exist
+        semantic_edges = [e for e in data["links"] if e.get("type") == "semantic"]
+        assert len(semantic_edges) == 0

--- a/tests/test_graph_builder_enrichment.py
+++ b/tests/test_graph_builder_enrichment.py
@@ -1,0 +1,203 @@
+"""Tests for researcher profile enrichment in GraphBuilder.build_from_kb_papers()."""
+
+import pytest
+
+from research_agent.explorer.graph_builder import GraphBuilder
+
+
+def _make_papers(researcher="Alice Smith", count=2):
+    """Create minimal KB paper dicts for testing."""
+    return [
+        {
+            "paper_id": f"paper_{i}",
+            "title": f"Paper {i} by {researcher}",
+            "researcher": researcher,
+            "fields": ["Sociology", "Urban Studies"],
+            "citation_count": 10 * (i + 1),
+        }
+        for i in range(count)
+    ]
+
+
+class _MockProfile:
+    """Mimics ResearcherProfile.to_dict() without importing the real class."""
+
+    def __init__(self, **kwargs):
+        self._data = kwargs
+
+    def to_dict(self):
+        return dict(self._data)
+
+
+class _MockRegistry:
+    """Mimics ResearcherRegistry.get(name) with a dict of profiles."""
+
+    def __init__(self, profiles: dict[str, _MockProfile]):
+        self._profiles = {k.lower().strip(): v for k, v in profiles.items()}
+
+    def get(self, name):
+        return self._profiles.get(name.lower().strip())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFromKbPapersWithoutRegistry:
+    def test_researcher_node_has_minimal_data(self):
+        gb = GraphBuilder()
+        papers = _make_papers("Alice Smith", count=2)
+        gb.build_from_kb_papers(papers, researcher_registry=None)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["label"] == "Alice Smith"
+        assert node["metadata"]["h_index"] is None
+        assert node["metadata"]["affiliations"] == []
+        assert node["id"] == "researcher:Alice Smith"
+
+
+class TestBuildFromKbPapersWithRegistryEnriches:
+    def test_enriched_node_has_full_profile(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id="S222",
+            h_index=25,
+            affiliations=["MIT"],
+            works_count=100,
+            citations_count=5000,
+            fields=["Sociology", "Geography"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        gb = GraphBuilder()
+        papers = _make_papers("Alice Smith", count=2)
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["metadata"]["h_index"] == 25
+        assert node["metadata"]["affiliations"] == ["MIT"]
+        assert node["id"] == "researcher:A111"
+        assert node["metadata"]["works_count"] == 100
+        assert node["metadata"]["citations"] == 5000
+
+
+class TestBuildFromKbPapersGracefulDegradation:
+    def test_unknown_researcher_gets_minimal_node(self):
+        registry = _MockRegistry({})  # empty — no profiles
+
+        gb = GraphBuilder()
+        papers = _make_papers("Bob Unknown", count=1)
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        researcher_nodes = [n for n in data["nodes"] if n["type"] == "researcher"]
+        assert len(researcher_nodes) == 1
+        node = researcher_nodes[0]
+        assert node["label"] == "Bob Unknown"
+        assert node["metadata"]["h_index"] is None
+        assert node["id"] == "researcher:Bob Unknown"
+
+
+class TestBuildFromKbPapersMixedEnrichment:
+    def test_one_enriched_one_minimal(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=25,
+            affiliations=["MIT"],
+            works_count=50,
+            citations_count=2000,
+            fields=["Sociology"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        papers = _make_papers("Alice Smith", count=1) + _make_papers("Bob Unknown", count=1)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        nodes_by_label = {n["label"]: n for n in data["nodes"] if n["type"] == "researcher"}
+        assert nodes_by_label["Alice Smith"]["metadata"]["h_index"] == 25
+        assert nodes_by_label["Bob Unknown"]["metadata"]["h_index"] is None
+
+
+class TestWorksCountUsesMax:
+    def test_registry_count_wins_when_larger(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=100,
+            citations_count=5000,
+            fields=[],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        # KB has 2 papers with 10+20=30 citations
+        papers = _make_papers("Alice Smith", count=2)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        assert node["metadata"]["works_count"] == 100  # registry wins
+        assert node["metadata"]["citations"] == 5000   # registry wins
+
+    def test_kb_count_wins_when_larger(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=1,       # registry has less
+            citations_count=5,   # registry has less
+            fields=[],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        papers = _make_papers("Alice Smith", count=2)  # 2 papers, 30 total cites
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        assert node["metadata"]["works_count"] == 2   # KB wins
+        assert node["metadata"]["citations"] == 30     # KB wins
+
+
+class TestFieldsMergedAndDeduplicated:
+    def test_fields_merged_without_dupes(self):
+        profile = _MockProfile(
+            name="Alice Smith",
+            openalex_id="A111",
+            semantic_scholar_id=None,
+            h_index=10,
+            affiliations=[],
+            works_count=0,
+            citations_count=0,
+            fields=["Sociology", "Tourism", "Geography"],
+        )
+        registry = _MockRegistry({"Alice Smith": profile})
+
+        # KB papers have ["Sociology", "Urban Studies"]
+        papers = _make_papers("Alice Smith", count=1)
+        gb = GraphBuilder()
+        gb.build_from_kb_papers(papers, researcher_registry=registry)
+        data = gb.to_dict()
+
+        node = [n for n in data["nodes"] if n["type"] == "researcher"][0]
+        fields = node["metadata"]["fields"]
+        # KB fields first, then registry additions (no dupes)
+        assert fields == ["Sociology", "Urban Studies", "Tourism", "Geography"]

--- a/tests/test_multi_model_pipeline.py
+++ b/tests/test_multi_model_pipeline.py
@@ -1,0 +1,339 @@
+"""
+Tests for the multi-model pipeline feature.
+
+Covers:
+- configure_pipeline accepts valid task types
+- configure_pipeline filters invalid task types
+- task_infer with no pipeline (uses default model)
+- task_infer with pipeline override (switches model)
+- task_infer restores original model after override
+- task_infer restores original model even on error
+- Pipeline config loading from YAML
+- resolve_pipeline_aliases with known and unknown providers
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_model_loading():
+    """Prevent actual model loading in tests."""
+    from research_agent.models.llm_utils import VRAMConstraintError
+
+    with patch("research_agent.agents.research_agent.get_qlora_pipeline") as mock_qlora, \
+         patch("research_agent.agents.research_agent.get_ollama_pipeline") as mock_ollama:
+        mock_qlora.side_effect = VRAMConstraintError("Model loading disabled in tests")
+        mock_ollama.side_effect = Exception("Ollama disabled in tests")
+        yield
+
+
+def _make_agent(**kwargs):
+    """Create a minimal ResearchAgent for testing."""
+    from research_agent.agents.research_agent import ResearchAgent
+    return ResearchAgent(use_ollama=False, **kwargs)
+
+
+def _make_agent_with_model():
+    """Create a ResearchAgent with a mocked OpenAI-compatible model."""
+    from research_agent.agents.research_agent import ResearchAgent
+
+    agent = ResearchAgent(use_ollama=False)
+
+    # Inject a mock model that supports switch_model
+    mock_model = MagicMock()
+    mock_model.model_name = "default-model"
+    mock_model.generate.return_value = "mock response"
+    mock_model.switch_model = MagicMock()
+    mock_model.list_available_models.return_value = [
+        "default-model", "fast-model", "big-model",
+    ]
+
+    agent.model = mock_model
+    agent.provider = "openai"
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# configure_pipeline
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestConfigurePipeline:
+
+    def test_accepts_valid_task_types(self):
+        agent = _make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        })
+        assert agent._pipeline == {
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        }
+
+    def test_filters_invalid_task_types(self):
+        agent = _make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "summarize": "some-model",       # invalid
+            "translate": "some-model",       # invalid
+        })
+        assert "classify" in agent._pipeline
+        assert "summarize" not in agent._pipeline
+        assert "translate" not in agent._pipeline
+
+    def test_empty_pipeline(self):
+        agent = _make_agent()
+        agent.configure_pipeline({})
+        assert agent._pipeline == {}
+
+    def test_partial_pipeline(self):
+        agent = _make_agent()
+        agent.configure_pipeline({"synthesize": "big-model"})
+        assert agent._pipeline == {"synthesize": "big-model"}
+        assert "classify" not in agent._pipeline
+
+    def test_warns_for_unknown_model(self):
+        """configure_pipeline should log a warning for unknown models."""
+        agent = _make_agent_with_model()
+        with patch("research_agent.agents.research_agent.logger") as mock_logger:
+            agent.configure_pipeline({"classify": "nonexistent-model"})
+            # Should have at least one warning about the unknown model
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "nonexistent-model" in str(c)
+            ]
+            assert len(warning_calls) >= 1
+
+    def test_no_warning_for_known_model(self):
+        """configure_pipeline should not warn for models in the known list."""
+        agent = _make_agent_with_model()
+        with patch("research_agent.agents.research_agent.logger") as mock_logger:
+            agent.configure_pipeline({"classify": "fast-model"})
+            # Should NOT have warnings about unknown models
+            warning_calls = [
+                c for c in mock_logger.warning.call_args_list
+                if "not in known model" in str(c)
+            ]
+            assert len(warning_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# task_infer
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestTaskInfer:
+
+    def test_no_pipeline_uses_default(self):
+        """With no pipeline configured, task_infer uses the default model."""
+        agent = _make_agent_with_model()
+        # No pipeline set -> _pipeline is empty
+        result = agent.task_infer("classify", "test prompt")
+        assert result == "mock response"
+        # switch_model should NOT be called
+        agent.model.switch_model.assert_not_called()
+
+    def test_pipeline_override_switches_model(self):
+        """With a pipeline override, task_infer switches to the specified model."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+
+        result = agent.task_infer("classify", "test prompt")
+        assert result == "mock response"
+
+        # Should have switched to fast-model, then back to default-model
+        calls = agent.model.switch_model.call_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0] == "fast-model"
+        assert calls[1].args[0] == "default-model"
+
+    def test_restores_original_model_after_override(self):
+        """After task_infer with override, the model is restored to the original."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"synthesize": "big-model"})
+
+        agent.task_infer("synthesize", "test prompt")
+
+        # Last call should restore to default-model
+        last_call = agent.model.switch_model.call_args_list[-1]
+        assert last_call.args[0] == "default-model"
+
+    def test_restores_model_on_error(self):
+        """Even if generate() raises, the model must be restored."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+        agent.model.generate.side_effect = RuntimeError("LLM failure")
+
+        # task_infer calls infer() which catches general exceptions
+        result = agent.task_infer("classify", "test prompt")
+        assert "Error" in result or "error" in result.lower()
+
+        # Model should still be restored to default
+        last_call = agent.model.switch_model.call_args_list[-1]
+        assert last_call.args[0] == "default-model"
+
+    def test_unmatched_task_uses_default(self):
+        """A task not in the pipeline should use the default model."""
+        agent = _make_agent_with_model()
+        agent.configure_pipeline({"classify": "fast-model"})
+
+        # "synthesize" is NOT in the pipeline
+        agent.task_infer("synthesize", "test prompt")
+        agent.model.switch_model.assert_not_called()
+
+    def test_no_model_returns_inference_result(self):
+        """With no model at all, task_infer should still return something."""
+        agent = _make_agent()
+        # agent.model is None (no LLM loaded)
+        result = agent.task_infer("classify", "test prompt")
+        # Should hit the infer() error handling path
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# resolve_pipeline_aliases
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestResolvePipelineAliases:
+
+    def test_resolves_fast_alias_for_groq(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "groq",
+        )
+        assert result["classify"] == "llama-3.1-8b-instant"
+        assert result["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_resolves_fast_alias_for_openai(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "openai",
+        )
+        assert result["classify"] == "gpt-4o-mini"
+        assert result["synthesize"] == "gpt-4o"
+
+    def test_resolves_fast_alias_for_anthropic(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "anthropic",
+        )
+        assert result["classify"] == "claude-haiku-4-5"
+        assert result["synthesize"] == "claude-sonnet-4-6"
+
+    def test_literal_model_name_passes_through(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "my-custom-model", "synthesize": "another-model"},
+            "groq",
+        )
+        assert result["classify"] == "my-custom-model"
+        assert result["synthesize"] == "another-model"
+
+    def test_unknown_provider_passes_through(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "synthesize": "default"},
+            "unknown_provider",
+        )
+        # No aliases known for unknown provider, so values pass through
+        assert result["classify"] == "fast"
+        assert result["synthesize"] == "default"
+
+    def test_mixed_aliases_and_literals(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases(
+            {"classify": "fast", "extract_keywords": "my-model", "synthesize": "default"},
+            "groq",
+        )
+        assert result["classify"] == "llama-3.1-8b-instant"
+        assert result["extract_keywords"] == "my-model"
+        assert result["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_empty_pipeline(self):
+        from research_agent.main import resolve_pipeline_aliases
+        result = resolve_pipeline_aliases({}, "groq")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline config loading from YAML
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestPipelineConfigLoading:
+
+    def test_pipeline_loaded_from_yaml(self, tmp_path):
+        """Pipeline section in YAML should be loadable and resolvable."""
+        from research_agent.utils.config import load_config
+        from research_agent.main import resolve_pipeline_aliases
+
+        cfg_file = tmp_path / "test_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+            "  pipeline:\n"
+            "    classify: fast\n"
+            "    extract_keywords: fast\n"
+            "    synthesize: default\n"
+        )
+
+        config = load_config(str(cfg_file))
+        model_cfg = config.get("model", {})
+        pipeline_cfg = model_cfg.get("pipeline")
+
+        assert pipeline_cfg is not None
+        assert isinstance(pipeline_cfg, dict)
+        assert pipeline_cfg["classify"] == "fast"
+
+        resolved = resolve_pipeline_aliases(pipeline_cfg, "groq")
+        assert resolved["classify"] == "llama-3.1-8b-instant"
+        assert resolved["synthesize"] == "llama-3.3-70b-versatile"
+
+    def test_no_pipeline_section(self, tmp_path):
+        """Config without pipeline section should not break anything."""
+        from research_agent.utils.config import load_config
+
+        cfg_file = tmp_path / "no_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+        )
+
+        config = load_config(str(cfg_file))
+        model_cfg = config.get("model", {})
+        pipeline_cfg = model_cfg.get("pipeline")
+
+        assert pipeline_cfg is None
+
+    def test_pipeline_with_literal_model_names(self, tmp_path):
+        """Pipeline with literal model names (no aliases) should pass through."""
+        from research_agent.utils.config import load_config
+        from research_agent.main import resolve_pipeline_aliases
+
+        cfg_file = tmp_path / "literal_pipeline.yaml"
+        cfg_file.write_text(
+            "model:\n"
+            "  provider: groq\n"
+            "  pipeline:\n"
+            "    classify: llama-3.1-8b-instant\n"
+            "    synthesize: llama-3.3-70b-versatile\n"
+        )
+
+        config = load_config(str(cfg_file))
+        pipeline_cfg = config["model"]["pipeline"]
+
+        resolved = resolve_pipeline_aliases(pipeline_cfg, "groq")
+        assert resolved["classify"] == "llama-3.1-8b-instant"
+        assert resolved["synthesize"] == "llama-3.3-70b-versatile"

--- a/tests/test_perplexity_integration.py
+++ b/tests/test_perplexity_integration.py
@@ -1,0 +1,368 @@
+"""
+Tests for Perplexity integration: LLM provider config and web search provider.
+
+All HTTP calls are mocked -- no real API key needed.
+"""
+
+import asyncio
+import os
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from research_agent.tools.web_search import (
+    WebSearchTool,
+    WebResult,
+    _extract_citation_snippet,
+    _title_from_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PERPLEXITY_RESPONSE = {
+    "id": "chatcmpl-test-123",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": (
+                    "According to recent research [1], climate change has "
+                    "significant impacts on Arctic ecosystems. Studies show [2] "
+                    "that permafrost thawing accelerates greenhouse gas release. "
+                    "Furthermore [3], indigenous communities are adapting their "
+                    "practices in response to these changes."
+                ),
+            }
+        }
+    ],
+    "citations": [
+        "https://example.com/arctic-climate-study",
+        "https://nature.com/permafrost-thawing-2024",
+        "https://indigenous-voices.org/adaptation-report",
+    ],
+}
+
+
+PERPLEXITY_RESPONSE_NO_CITATIONS = {
+    "id": "chatcmpl-test-456",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "Climate change affects many regions worldwide.",
+            }
+        }
+    ],
+    # No citations field at all
+}
+
+
+PERPLEXITY_RESPONSE_EMPTY_CITATIONS = {
+    "id": "chatcmpl-test-789",
+    "model": "sonar",
+    "choices": [
+        {
+            "message": {
+                "role": "assistant",
+                "content": "Some general information about the topic.",
+            }
+        }
+    ],
+    "citations": [],
+}
+
+
+def _make_mock_response(data: dict, status_code: int = 200) -> httpx.Response:
+    """Build a fake httpx.Response from a dict."""
+    response = httpx.Response(
+        status_code=status_code,
+        json=data,
+        request=httpx.Request("POST", "https://api.perplexity.ai/chat/completions"),
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# 1. CLOUD_PROVIDERS config
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityCloudProvider:
+    """Verify perplexity entry in CLOUD_PROVIDERS."""
+
+    def test_perplexity_in_cloud_providers(self):
+        from research_agent.main import CLOUD_PROVIDERS
+
+        assert "perplexity" in CLOUD_PROVIDERS
+
+    def test_perplexity_provider_fields(self):
+        from research_agent.main import CLOUD_PROVIDERS
+
+        cfg = CLOUD_PROVIDERS["perplexity"]
+        assert cfg["name"] == "Perplexity AI"
+        assert cfg["base_url"] == "https://api.perplexity.ai"
+        assert cfg["api_key_env"] == "PERPLEXITY_API_KEY"
+        assert cfg["default_model"] == "sonar"
+        assert "sonar" in cfg["models"]
+        assert "sonar-pro" in cfg["models"]
+        assert "sonar-reasoning" in cfg["models"]
+
+    def test_perplexity_in_auto_detection_order(self):
+        """Perplexity should be checked after groq but before openrouter."""
+        from research_agent.main import detect_available_provider
+
+        # With only PERPLEXITY_API_KEY set, it should be selected
+        env = {"PERPLEXITY_API_KEY": "pplx-test-key"}
+        with patch.dict(os.environ, env, clear=False):
+            # Clear other keys that might take priority
+            for key in ["OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GROQ_API_KEY"]:
+                os.environ.pop(key, None)
+            provider, cfg = detect_available_provider({})
+            assert provider == "perplexity"
+            assert cfg["name"] == "Perplexity AI"
+
+
+# ---------------------------------------------------------------------------
+# 2. WebSearchTool provider selection
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityProviderSelection:
+    """Verify perplexity is accepted as a web search provider."""
+
+    def test_create_with_perplexity_provider(self):
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+        assert tool.provider == "perplexity"
+        assert tool.api_key == "pplx-test"
+
+    def test_search_dispatches_to_perplexity(self):
+        """search() should call _search_perplexity for perplexity provider."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+        mock = AsyncMock(return_value=[])
+        tool._search_perplexity = mock
+
+        asyncio.get_event_loop().run_until_complete(
+            tool.search("test query")
+        )
+        mock.assert_called_once_with("test query", 10)
+
+
+# ---------------------------------------------------------------------------
+# 3. _search_perplexity() with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPerplexity:
+    """Test the _search_perplexity method with mocked API calls."""
+
+    def test_missing_api_key_raises(self):
+        tool = WebSearchTool(api_key=None, provider="perplexity")
+        with pytest.raises(ValueError, match="Perplexity API key required"):
+            asyncio.get_event_loop().run_until_complete(
+                tool._search_perplexity("test query", max_results=10)
+            )
+
+    def test_successful_search_with_citations(self):
+        """Normal response with citations returns WebResult per citation."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("Arctic climate change", max_results=10)
+        )
+
+        assert len(results) == 3
+        assert all(isinstance(r, WebResult) for r in results)
+
+        # First result
+        assert results[0].url == "https://example.com/arctic-climate-study"
+        assert results[0].content  # should have snippet text
+        assert results[0].raw_content is not None  # first result gets raw_content
+
+        # Second result
+        assert results[1].url == "https://nature.com/permafrost-thawing-2024"
+        assert results[1].raw_content is None  # only first gets raw_content
+
+        # Third result
+        assert results[2].url == "https://indigenous-voices.org/adaptation-report"
+
+    def test_max_results_limits_citations(self):
+        """When max_results < len(citations), only that many are returned."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("test", max_results=2)
+        )
+
+        assert len(results) == 2
+
+    def test_no_citations_returns_single_result(self):
+        """Response without citations wraps whole answer as one WebResult."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE_NO_CITATIONS)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("climate change effects", max_results=10)
+        )
+
+        assert len(results) == 1
+        assert results[0].url == ""
+        assert "Climate change" in results[0].content
+        assert results[0].raw_content is not None
+
+    def test_empty_citations_returns_single_result(self):
+        """Response with empty citations list wraps whole answer."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE_EMPTY_CITATIONS)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("topic info", max_results=10)
+        )
+
+        assert len(results) == 1
+        assert results[0].url == ""
+
+    def test_http_error_returns_empty(self):
+        """HTTP errors should return empty list, not crash."""
+        tool = WebSearchTool(api_key="pplx-test", provider="perplexity")
+
+        mock_response = _make_mock_response({}, status_code=500)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        results = asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("test query", max_results=10)
+        )
+
+        assert results == []
+
+    def test_request_format(self):
+        """Verify the request is sent with correct headers and body."""
+        tool = WebSearchTool(api_key="pplx-secret-key", provider="perplexity")
+
+        mock_response = _make_mock_response(PERPLEXITY_RESPONSE)
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        tool._client = mock_client
+
+        asyncio.get_event_loop().run_until_complete(
+            tool._search_perplexity("my query", max_results=10)
+        )
+
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "https://api.perplexity.ai/chat/completions"
+        headers = call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer pplx-secret-key"
+        assert headers["Content-Type"] == "application/json"
+        body = call_args[1]["json"]
+        assert body["model"] == "sonar"
+        assert body["messages"][0]["content"] == "Search: my query"
+
+
+# ---------------------------------------------------------------------------
+# 4. Citation extraction helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCitationHelpers:
+    """Test the helper functions for citation parsing."""
+
+    def test_extract_citation_snippet_found(self):
+        content = "Climate change is real [1] and affects everyone [2] globally."
+        snippet = _extract_citation_snippet(content, "[1]", context_chars=20)
+        assert "[1]" in snippet
+        assert len(snippet) > 0
+
+    def test_extract_citation_snippet_not_found(self):
+        content = "No citations here."
+        snippet = _extract_citation_snippet(content, "[5]")
+        assert snippet == ""
+
+    def test_extract_citation_snippet_at_start(self):
+        content = "[1] This is the first point."
+        snippet = _extract_citation_snippet(content, "[1]", context_chars=50)
+        assert "[1]" in snippet
+
+    def test_title_from_url_with_path(self):
+        title = _title_from_url("https://www.example.com/articles/my-great-article")
+        assert "my great article" in title
+        assert "example.com" in title
+
+    def test_title_from_url_no_path(self):
+        title = _title_from_url("https://example.com/")
+        assert "example.com" in title
+
+    def test_title_from_url_long_slug(self):
+        long_slug = "a-very-" + "long-" * 20 + "title"
+        title = _title_from_url(f"https://example.com/{long_slug}")
+        assert len(title) < 100  # should be truncated
+
+    def test_title_from_url_invalid(self):
+        title = _title_from_url("not-a-url")
+        # Should not crash
+        assert isinstance(title, str)
+
+
+# ---------------------------------------------------------------------------
+# 5. Initialization in main.py
+# ---------------------------------------------------------------------------
+
+
+class TestPerplexityWebSearchInit:
+    """Verify that main.py wires up perplexity web search correctly."""
+
+    def test_perplexity_api_key_loaded(self):
+        """When provider is perplexity, PERPLEXITY_API_KEY should be used."""
+        config = {
+            "model": {"provider": "none"},
+            "search": {
+                "web_search": {
+                    "enabled": True,
+                    "provider": "perplexity",
+                }
+            },
+        }
+
+        with patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pplx-from-env"}):
+            # Import and test the web search init logic
+            from research_agent.main import build_agent_from_config
+
+            # We can't easily run build_agent_from_config without all deps,
+            # so test the config parsing logic directly
+            search_cfg = config.get("search", {})
+            web_cfg = search_cfg.get("web_search", {}) or {}
+            web_provider = web_cfg.get("provider", "duckduckgo")
+            web_api_key = None
+            if web_provider == "tavily":
+                web_api_key = os.getenv("TAVILY_API_KEY")
+            elif web_provider == "serper":
+                web_api_key = os.getenv("SERPER_API_KEY")
+            elif web_provider == "perplexity":
+                web_api_key = os.getenv("PERPLEXITY_API_KEY")
+
+            assert web_provider == "perplexity"
+            assert web_api_key == "pplx-from-env"

--- a/tests/test_pipeline_ui.py
+++ b/tests/test_pipeline_ui.py
@@ -1,0 +1,120 @@
+"""Tests for pipeline model configuration logic."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestConfigurePipelineFromUI:
+    """Test the pipeline dict construction from UI dropdown values."""
+
+    def _build_pipeline(self, classify, keywords, synthesize):
+        """Replicate the UI handler logic for building pipeline dict."""
+        pipeline = {}
+        if classify and classify != "default":
+            pipeline["classify"] = classify
+        if keywords and keywords != "default":
+            pipeline["extract_keywords"] = keywords
+        if synthesize and synthesize != "default":
+            pipeline["synthesize"] = synthesize
+        return pipeline
+
+    def test_all_default(self):
+        """All 'default' → empty pipeline dict."""
+        result = self._build_pipeline("default", "default", "default")
+        assert result == {}
+
+    def test_fast_classify(self):
+        """Only classify overridden."""
+        result = self._build_pipeline("llama-3.1-8b-instant", "default", "default")
+        assert result == {"classify": "llama-3.1-8b-instant"}
+
+    def test_all_overridden(self):
+        """All three tasks overridden."""
+        result = self._build_pipeline(
+            "gpt-4o-mini", "gpt-4o-mini", "gpt-4o"
+        )
+        assert result == {
+            "classify": "gpt-4o-mini",
+            "extract_keywords": "gpt-4o-mini",
+            "synthesize": "gpt-4o",
+        }
+
+    def test_empty_string_treated_as_default(self):
+        """Empty string → not included in pipeline."""
+        result = self._build_pipeline("", "default", "gpt-4o")
+        assert result == {"synthesize": "gpt-4o"}
+
+    def test_none_treated_as_default(self):
+        """None → not included in pipeline."""
+        result = self._build_pipeline(None, None, None)
+        assert result == {}
+
+
+class TestPipelineChoices:
+    """Test pipeline dropdown choices construction."""
+
+    def test_choices_include_default(self):
+        """'default' is always first in choices."""
+        models = ["gpt-4o-mini", "gpt-4o"]
+        choices = ["default"] + models
+        assert choices[0] == "default"
+        assert len(choices) == 3
+
+    def test_choices_with_no_models(self):
+        """When no models available, only 'default'."""
+        models = []
+        choices = ["default"] + models if models else ["default"]
+        assert choices == ["default"]
+
+
+@pytest.fixture(autouse=True)
+def mock_model_loading():
+    """Prevent actual model loading."""
+    from research_agent.models.llm_utils import VRAMConstraintError
+
+    with patch("research_agent.agents.research_agent.get_qlora_pipeline") as mock_qlora, \
+         patch("research_agent.agents.research_agent.get_ollama_pipeline") as mock_ollama:
+        mock_qlora.side_effect = VRAMConstraintError("disabled in tests")
+        mock_ollama.side_effect = Exception("disabled in tests")
+        yield
+
+
+class TestAgentConfigurePipeline:
+    """Test that agent.configure_pipeline() works with UI-style dicts."""
+
+    def _make_agent(self):
+        from research_agent.agents.research_agent import ResearchAgent
+        return ResearchAgent(
+            vector_store=MagicMock(),
+            embedder=MagicMock(),
+            use_ollama=False,
+        )
+
+    def test_valid_tasks_accepted(self):
+        """Valid task types are stored."""
+        agent = self._make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "extract_keywords": "fast-model",
+            "synthesize": "big-model",
+        })
+        assert agent._pipeline["classify"] == "fast-model"
+        assert agent._pipeline["synthesize"] == "big-model"
+
+    def test_empty_pipeline_clears(self):
+        """Empty dict clears all overrides."""
+        agent = self._make_agent()
+        agent.configure_pipeline({"classify": "fast"})
+        assert len(agent._pipeline) == 1
+        agent.configure_pipeline({})
+        assert len(agent._pipeline) == 0
+
+    def test_unknown_tasks_ignored(self):
+        """Unknown task types are silently filtered out."""
+        agent = self._make_agent()
+        agent.configure_pipeline({
+            "classify": "fast-model",
+            "unknown_task": "some-model",
+        })
+        assert "classify" in agent._pipeline
+        assert "unknown_task" not in agent._pipeline

--- a/tests/test_researcher_persistence.py
+++ b/tests/test_researcher_persistence.py
@@ -1,0 +1,204 @@
+"""Tests for researcher persistence: KB paper linking and auto-link."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from research_agent.db.kb_metadata_store import KBMetadataStore
+from research_agent.tools.researcher_lookup import ResearcherProfile
+
+
+# ============================================
+# Fixtures
+# ============================================
+
+
+@pytest.fixture()
+def meta_store(tmp_path):
+    """Fresh KBMetadataStore in a temp directory."""
+    return KBMetadataStore(path=str(tmp_path / "kb_meta.sqlite"))
+
+
+@pytest.fixture()
+def registry():
+    """Fresh ResearcherRegistry (not singleton — mocked for isolation)."""
+    from research_agent.tools.researcher_registry import ResearcherRegistry
+
+    reg = object.__new__(ResearcherRegistry)
+    reg._researchers = {}
+    reg._registry_lock = __import__("threading").Lock()
+    reg._store = MagicMock()
+    profiles = [
+        ResearcherProfile(name="David Harvey", normalized_name="david harvey"),
+        ResearcherProfile(name="Donna Haraway", normalized_name="donna haraway"),
+    ]
+    for p in profiles:
+        key = p.normalized_name or p.name.lower().strip()
+        reg._researchers[key] = p
+    return reg
+
+
+@pytest.fixture()
+def vector_store(tmp_path, meta_store):
+    """Minimal ResearchVectorStore with tmp ChromaDB + shared meta_store."""
+    from research_agent.db.vector_store import ResearchVectorStore
+
+    store = ResearchVectorStore(
+        persist_dir=str(tmp_path / "chroma"),
+        metadata_store_path=str(tmp_path / "kb_meta.sqlite"),
+    )
+    # Replace the auto-created meta with our shared one
+    store._meta = meta_store
+    return store
+
+
+def _seed_papers(meta_store):
+    """Insert test papers into SQLite."""
+    meta_store.upsert_paper(
+        "p1", "Spaces of Capital", "2025-01-01T00:00:00Z",
+        authors="David Harvey, Neil Smith", researcher="",
+    )
+    meta_store.upsert_paper(
+        "p2", "Simians Cyborgs Women", "2025-01-02T00:00:00Z",
+        authors="Donna Haraway", researcher="",
+    )
+    meta_store.upsert_paper(
+        "p3", "Random Paper", "2025-01-03T00:00:00Z",
+        authors="John Doe", researcher="",
+    )
+    meta_store.upsert_paper(
+        "p4", "Already Linked", "2025-01-04T00:00:00Z",
+        authors="David Harvey", researcher="David Harvey",
+    )
+    meta_store.upsert_paper(
+        "p5", "No Authors", "2025-01-05T00:00:00Z",
+        authors="",
+    )
+
+
+# ============================================
+# KBMetadataStore new methods
+# ============================================
+
+
+class TestUpdatePaperResearcher:
+    def test_updates_existing(self, meta_store):
+        meta_store.upsert_paper("p1", "Title", "2025-01-01T00:00:00Z")
+        assert meta_store.update_paper_researcher("p1", "David Harvey") is True
+        row = meta_store.get_paper("p1")
+        assert row["researcher"] == "David Harvey"
+
+    def test_returns_false_for_missing(self, meta_store):
+        assert meta_store.update_paper_researcher("missing", "Nobody") is False
+
+
+class TestCountPapersByResearcher:
+    def test_counts_correctly(self, meta_store):
+        meta_store.upsert_paper(
+            "p1", "A", "2025-01-01T00:00:00Z", researcher="Harvey"
+        )
+        meta_store.upsert_paper(
+            "p2", "B", "2025-01-02T00:00:00Z", researcher="Harvey"
+        )
+        meta_store.upsert_paper(
+            "p3", "C", "2025-01-03T00:00:00Z", researcher="Other"
+        )
+        assert meta_store.count_papers_by_researcher("Harvey") == 2
+        assert meta_store.count_papers_by_researcher("Other") == 1
+        assert meta_store.count_papers_by_researcher("Nobody") == 0
+
+
+class TestListUnlinkedPapers:
+    def test_returns_only_unlinked_with_authors(self, meta_store):
+        _seed_papers(meta_store)
+        unlinked = meta_store.list_unlinked_papers()
+        ids = {p["paper_id"] for p in unlinked}
+        # p1, p2, p3 are unlinked with authors
+        # p4 is linked, p5 has no authors
+        assert ids == {"p1", "p2", "p3"}
+
+
+# ============================================
+# ResearcherRegistry.match_author_name
+# ============================================
+
+
+class TestMatchAuthorName:
+    def test_exact_match(self, registry):
+        assert registry.match_author_name("David Harvey") == "David Harvey"
+
+    def test_case_insensitive(self, registry):
+        assert registry.match_author_name("david harvey") == "David Harvey"
+        assert registry.match_author_name("DONNA HARAWAY") == "Donna Haraway"
+
+    def test_no_match(self, registry):
+        assert registry.match_author_name("Unknown Person") is None
+
+    def test_empty_string(self, registry):
+        assert registry.match_author_name("") is None
+        assert registry.match_author_name("  ") is None
+
+
+# ============================================
+# researcher_linker
+# ============================================
+
+
+class TestLinkPapersToResearchers:
+    def test_full_scan_links_matching(self, vector_store, meta_store, registry):
+        from research_agent.db.researcher_linker import link_papers_to_researchers
+
+        _seed_papers(meta_store)
+        linked, scanned = link_papers_to_researchers(vector_store, registry)
+        assert scanned == 3  # p1, p2, p3 (unlinked with authors)
+        assert linked == 2  # p1 (Harvey), p2 (Haraway)
+
+        # Verify SQLite was updated
+        row1 = meta_store.get_paper("p1")
+        assert row1["researcher"] == "David Harvey"
+        row2 = meta_store.get_paper("p2")
+        assert row2["researcher"] == "Donna Haraway"
+
+    def test_no_false_positives(self, vector_store, meta_store, registry):
+        from research_agent.db.researcher_linker import link_papers_to_researchers
+
+        _seed_papers(meta_store)
+        link_papers_to_researchers(vector_store, registry)
+        # p3 (John Doe) should remain unlinked
+        row3 = meta_store.get_paper("p3")
+        assert row3["researcher"] == ""
+
+    def test_idempotent(self, vector_store, meta_store, registry):
+        from research_agent.db.researcher_linker import link_papers_to_researchers
+
+        _seed_papers(meta_store)
+        linked1, _ = link_papers_to_researchers(vector_store, registry)
+        linked2, scanned2 = link_papers_to_researchers(vector_store, registry)
+        assert linked1 == 2
+        assert linked2 == 0  # already linked, not in unlinked list
+        assert scanned2 == 1  # only p3 remains unlinked
+
+
+class TestLinkPapersForResearcher:
+    def test_targeted_link(self, vector_store, meta_store, registry):
+        from research_agent.db.researcher_linker import link_papers_for_researcher
+
+        _seed_papers(meta_store)
+        linked = link_papers_for_researcher(vector_store, "David Harvey")
+        assert linked == 1  # p1
+
+        row = meta_store.get_paper("p1")
+        assert row["researcher"] == "David Harvey"
+
+        # p2 should not be linked (Donna Haraway, not David Harvey)
+        row2 = meta_store.get_paper("p2")
+        assert row2["researcher"] == ""
+
+    def test_no_match_returns_zero(self, vector_store, meta_store, registry):
+        from research_agent.db.researcher_linker import link_papers_for_researcher
+
+        _seed_papers(meta_store)
+        linked = link_papers_for_researcher(vector_store, "Nobody Here")
+        assert linked == 0

--- a/tests/test_web_search_switch.py
+++ b/tests/test_web_search_switch.py
@@ -1,0 +1,43 @@
+"""Tests for WebSearchTool provider switching."""
+
+import pytest
+from research_agent.tools.web_search import WebSearchTool
+
+
+class TestSetProvider:
+    def test_switch_to_perplexity(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("perplexity", api_key="pplx-test")
+        assert tool.provider == "perplexity"
+        assert tool.api_key == "pplx-test"
+
+    def test_switch_to_duckduckgo(self):
+        tool = WebSearchTool(provider="perplexity", api_key="key")
+        tool.set_provider("duckduckgo")
+        assert tool.provider == "duckduckgo"
+
+    def test_switch_to_tavily(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("tavily", api_key="tvly-test")
+        assert tool.provider == "tavily"
+
+    def test_switch_to_serper(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        tool.set_provider("serper", api_key="serp-test")
+        assert tool.provider == "serper"
+
+    def test_invalid_provider_raises(self):
+        tool = WebSearchTool(provider="duckduckgo")
+        with pytest.raises(ValueError, match="Unknown provider"):
+            tool.set_provider("google")
+
+    def test_api_key_preserved_when_not_provided(self):
+        tool = WebSearchTool(provider="tavily", api_key="original-key")
+        tool.set_provider("perplexity")
+        # api_key unchanged since we didn't pass a new one
+        assert tool.api_key == "original-key"
+
+    def test_api_key_updated_when_provided(self):
+        tool = WebSearchTool(provider="tavily", api_key="old-key")
+        tool.set_provider("perplexity", api_key="new-key")
+        assert tool.api_key == "new-key"


### PR DESCRIPTION
## Summary
When someone drops their Anthropic API key, Claude now uses **native tool calling** to decide which research tools to invoke and in what order — instead of following the rigid LangGraph pipeline (understand → search local → search external → synthesize → offer ingestion).

- **3 tools exposed**: `search_local_kb`, `search_academic`, `search_web`
- **Claude decides the routing**: search local first, skip external if enough results, refine queries, call web for grey literature — whatever makes sense for the query
- **Same output format**: UI doesn't change at all — same result dict with `answer`, `sources`, `query_type`
- **Clean fallback**: if `anthropic` SDK isn't installed or API fails, silently falls back to LangGraph
- **Other providers unaffected**: Groq, OpenAI, Ollama etc. keep using the LangGraph pipeline as before

### How it works
1. `canonical_provider` threaded through init chain (was lost when remapped to `"openai"` transport)
2. `is_claude` property detects Anthropic provider + API key
3. `_run_async()` branches to `_run_with_claude_tools()` before `graph.ainvoke()`
4. Claude gets system prompt + tool definitions → calls tools → we execute → feed results back → Claude synthesizes with `[1]`, `[2]` citations
5. `MAX_TURNS = 6` safety limit prevents infinite loops

### Files changed
- `src/research_agent/agents/research_agent.py` — `canonical_provider` param, `is_claude` property, 6 new methods (~350 lines), branch in `_run_async()`
- `src/research_agent/main.py` — pass `canonical_provider` through (1 line)
- `tests/test_claude_tools.py` — 25 new tests (all mocked, zero API credits)
- `docs/CHANGELOG.md` + `docs/ROADMAP.md` — updated

## Test plan
- [x] 25 new Claude tool-use tests passing (detection, schemas, dispatch, full loop, format parity, fallback, BYOK)
- [x] Full suite: 400 passed, 0 failures
- [ ] Smoke test with real `ANTHROPIC_API_KEY`

@claude please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)